### PR TITLE
Close DSYS-98: Add Light DOM styles to cards carousel component

### DIFF
--- a/packages/components/source/components/carousel-cards/styles/light-dom.css
+++ b/packages/components/source/components/carousel-cards/styles/light-dom.css
@@ -3,8 +3,15 @@ umd-element-carousel-cards:not(:defined) {
 }
 
 umd-element-carousel-cards {
-  & [slot='cards'],
   & [slot='intro'] {
-    background-color: theme(colors.black);
+    & .umd-rich-text,
+    & a[class^='umd-cta'] {
+      color: theme(colors.white);
+    }
+
+    & .umd-rich-text a:hover,
+    & .umd-rich-text a:focus {
+      color: theme(colors.gold);
+    }
   }
 }


### PR DESCRIPTION
Removed the enforced background, added accessible text and link colors.