### PR TITLE
Close DSYS-197: Right align list item indicators in rich text

### DIFF
--- a/packages/configuration/source/common/rich-text-lists.ts
+++ b/packages/configuration/source/common/rich-text-lists.ts
@@ -21,7 +21,7 @@ const listStylesBase = {
         counterIncrement: 'item',
         position: 'absolute',
         top: '0',
-        left: '0',
+        right: `calc(100% - ${spacing.xs})`,
       },
     },
 
@@ -29,7 +29,7 @@ const listStylesBase = {
       paddingLeft: spacing.xl,
 
       '&:before': {
-        left: spacing.sm,
+        right: `calc(100% - ${spacing.md})`,
       },
     },
   },
@@ -39,6 +39,7 @@ const listStylesBase = {
     padding: '0',
     counterReset: 'item',
     listStyleType: 'none !important',
+
     '& li ': {
       paddingLeft: spacing.xl,
       position: 'relative',
@@ -52,7 +53,7 @@ const listStylesBase = {
         fontVariantNumeric: 'tabular-nums',
         position: 'absolute',
         top: '0',
-        left: '0',
+        right: `calc(100% - ${spacing.md})`,
         unicodeBidi: 'isolate',
         whiteSpace: 'pre',
       },
@@ -68,7 +69,7 @@ const listStylesBase = {
       content: 'counter(item)',
       borderRight: `1px solid ${colors.red}`,
       paddingRight: spacing.min,
-      left: spacing.xs,
+      right: `calc(100% - ${spacing.lg})`,
     },
   },
 

--- a/packages/kitchen-sink/source/twig/configuration.twig
+++ b/packages/kitchen-sink/source/twig/configuration.twig
@@ -11,16 +11,6 @@
   <body>
     {% include '_components/header.twig' %}
 
-    {# <a href="#main" class="umd-skip-content">Skip to Main Content</a>
-    <header class="p-md">
-      <div class="umd-lock">
-        <a href="/" class="umd-cta-secondary mb-md">
-          <!-- prettier-ignore -->
-          <svg aria-hidden="true" width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M39.9149 15.7825L67.7095 15.7653L58.5274 25.1688H2V87.9014H65.8332V33.8977L75.175 24.3307L75.1772 50.9945L86.9542 38.8741L86.9553 15.7534L87 15.7533V4L86.9559 4.00009L75.1734 4.00008L52.0353 4L39.9149 15.7825ZM49.1033 34.8199L33.3385 50.9647L41.3474 58.9736L56.0127 43.9548V78.2502H11.8205V34.8199H49.1033Z"  /></svg>
-          <span>Back to Components List</span>
-        </a>
-      </div>
-    </header> #}
     <main id="main">
       <section class="pb-2xl">
         <div class="umd-lock">


### PR DESCRIPTION
Fix for [DSYS-197](https://linear.app/umd-web-services/issue/DSYS-197/ordered-list-items-that-go-into-double-digits-overlap-with-the-text). and [PROV-577](https://linear.app/umd-web-services/issue/PROV-577/style-tweak-numbered-list-separator-overlapping-text).

Rebased on main and tested before creating this PR.