### PR TITLE
Add animated link helper classes to the configuration

### DIFF
--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/umd-web-configuration",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "UMD Design System Tokens and Common Classes by the Web Services Team in the Office of Marketing and Communications",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/configuration/source/common/animated-links.ts
+++ b/packages/configuration/source/common/animated-links.ts
@@ -1,0 +1,183 @@
+import { colors } from '../tokens/colors';
+
+const baseSpan = {
+  display: 'inline',
+  position: 'relative',
+  backgroundPosition: 'left calc(100% - 0.125em)',
+  backgroundRepeat: 'no-repeat',
+  transition: 'background 0.5s',
+};
+
+const baseLink = {
+  position: 'relative',
+  textDecoration: 'none',
+};
+
+const baseAnimation = {
+  '.umd-slidein-underline': {
+    ...baseLink,
+
+    [`&:hover > *:not(svg):not(.sr-only),
+      &:focus > *:not(svg):not(.sr-only)`]: {
+      backgroundSize: '100% 2px',
+    },
+  },
+
+  '.umd-fadein-underline': {
+    ...baseLink,
+
+    [`&:hover > *:not(svg):not(.sr-only),
+      &:focus > *:not(svg):not(.sr-only)`]: {
+      backgroundSize: '100% 2px',
+    },
+  },
+};
+
+const slideInUnderline = {
+  '.umd-slidein-underline-red': {
+    ...baseAnimation['.umd-slidein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '0 2px',
+      backgroundImage: `linear-gradient(${colors.red}, ${colors.red})`,
+    },
+  },
+
+  '.umd-slidein-underline-gold': {
+    ...baseAnimation['.umd-slidein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '0 2px',
+      backgroundImage: `linear-gradient(${colors.gold}, ${colors.gold})`,
+    },
+  },
+
+  '.umd-slidein-underline-black': {
+    ...baseAnimation['.umd-slidein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '0 2px',
+      backgroundImage: `linear-gradient(${colors.black}, ${colors.black})`,
+    },
+  },
+
+  '.umd-slidein-underline-white': {
+    ...baseAnimation['.umd-slidein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '0 2px',
+      backgroundImage: `linear-gradient(${colors.white}, ${colors.white})`,
+    },
+  },
+};
+
+const fadeInUnderline = {
+  '.umd-fadein-underline-red': {
+    ...baseAnimation['.umd-fadein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '100% 0',
+      backgroundImage: `linear-gradient(${colors.red}, ${colors.red})`,
+    },
+  },
+
+  '.umd-fadein-underline-gray': {
+    ...baseAnimation['.umd-fadein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '100% 0',
+      backgroundImage: `linear-gradient(${colors.gray.mediumAA}, ${colors.gray.mediumAA})`,
+    },
+  },
+
+  '.umd-fadein-underline-gold': {
+    ...baseAnimation['.umd-fadein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '100% 0',
+      backgroundImage: `linear-gradient(${colors.gold}, ${colors.gold})`,
+    },
+  },
+
+  '.umd-fadein-underline-black': {
+    ...baseAnimation['.umd-fadein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '100% 0',
+      backgroundImage: `linear-gradient(${colors.black}, ${colors.black})`,
+    },
+  },
+
+  '.umd-fadein-underline-white': {
+    ...baseAnimation['.umd-fadein-underline'],
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundSize: '100% 0',
+      backgroundImage: `linear-gradient(${colors.white}, ${colors.white})`,
+    },
+  },
+};
+
+const specialAnimations = {
+  '.umd-slidein-underline-gray-red': {
+    ...baseLink,
+
+    '& > *:not(svg):not(.sr-only)': {
+      ...baseSpan,
+
+      backgroundImage: `linear-gradient(to left, ${colors.gray.light} 50%, ${colors.red} 50% 100%)`,
+      backgroundPosition: 'right bottom',
+      backgroundSize: '200% 2px',
+    },
+
+    [`&:hover > *:not(svg):not(.sr-only),
+      &:focus > *:not(svg):not(.sr-only)`]: {
+      backgroundPosition: 'left bottom',
+      backgroundSize: '200% 2px',
+    },
+  },
+
+  '.umd-fadein-simple-dark': {
+    ...baseLink,
+    backgroundImage: `linear-gradient(${colors.white}, ${colors.white})`,
+    backgroundPosition: 'left calc(100% - 2px)',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: '100% 1px',
+    color: colors.white,
+    transition: 'color 0.5s, background-image 0.5s, background-position 0.5s',
+
+    [`&:hover,
+    &:focus`]: {
+      backgroundImage: `linear-gradient(${colors.gold}, ${colors.gold})`,
+      backgroundPosition: 'left calc(100%)',
+      color: colors.white,
+      textDecoration: 'none',
+    },
+  },
+};
+
+const animatedLinks = Object.assign(
+  slideInUnderline,
+  fadeInUnderline,
+  specialAnimations,
+);
+
+export { animatedLinks };

--- a/packages/configuration/source/common/rich-text.ts
+++ b/packages/configuration/source/common/rich-text.ts
@@ -4,6 +4,7 @@ import { spacing } from '../tokens/layout';
 import { icons } from '../assets/icons';
 import { typography } from './typography';
 import { richTextlists } from './rich-text-lists';
+import { animatedLinks } from '../common/animated-links';
 
 const richTextBase = {
   '& > *': {
@@ -147,6 +148,13 @@ const richText = {
     ...blockquotes,
     ...tables,
     ...richTextlists,
+  },
+  '.umd-rich-text-dark': {
+    color: colors.white,
+
+    '& a': {
+      ...animatedLinks['.umd-fadein-simple-dark'],
+    },
   },
 };
 

--- a/packages/configuration/source/index.ts
+++ b/packages/configuration/source/index.ts
@@ -11,6 +11,7 @@ import { root } from './dependancies/root';
 
 import { skipContent } from './common/accessibility';
 import { typography } from './common/typography';
+import { animatedLinks } from './common/animated-links';
 import { richText } from './common/rich-text';
 import { umdFlexGrid } from './layout/umd-flex';
 import { umdGrid } from './layout/umd-grid';
@@ -23,6 +24,7 @@ import { umdLoader } from './elements/loader';
 const umdUtilities = { ...root };
 const umdComponents = {
   ...skipContent,
+  ...animatedLinks,
   ...richText,
   ...typography,
   ...umdGrid,

--- a/packages/kitchen-sink/source/twig/configuration.twig
+++ b/packages/kitchen-sink/source/twig/configuration.twig
@@ -81,6 +81,14 @@
                           </a>
                         </li>
                         <li>
+                          Link Animations
+                          <a href="#link-animations">
+                            <em>
+                              [.umd-slidein-underline-*,umd-fadein-underline-*]
+                            </em>
+                          </a>
+                        </li>
+                        <li>
                           Image with caption
                           <a href="#image-caption">
                             <em>[.umd-media-with-caption, .umd-caption]</em>
@@ -1860,6 +1868,92 @@
                 <svg aria-hidden="true" width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M39.9149 15.7825L67.7095 15.7653L58.5274 25.1688H2V87.9014H65.8332V33.8977L75.175 24.3307L75.1772 50.9945L86.9542 38.8741L86.9553 15.7534L87 15.7533V4L86.9559 4.00009L75.1734 4.00008L52.0353 4L39.9149 15.7825ZM49.1033 34.8199L33.3385 50.9647L41.3474 58.9736L56.0127 43.9548V78.2502H11.8205V34.8199H49.1033Z"  /></svg>
                 <span>Secondary Call to Action Link</span>
               </a>
+            </div>
+          </div>
+
+          <div class="umd-configuration-section">
+            <h2 id="link-animations" class="umd-section-headline">
+              Animated Link style classes
+            </h2>
+
+            <div class="umd-rich-text mb-md">
+              <p>
+                Useful for adding animations to links used in titles and non-cta
+                locations
+              </p>
+            </div>
+
+            <h3 class="my-md umd-sans-small font-bold text-gray-mediumAA">
+              Slide-in Animations
+            </h3>
+
+            <div class="flex flex-col items-start gap-y-sm">
+              <a href="#" class="umd-sans-larger umd-slidein-underline-red">
+                <span>UMD Slidein Underline Red</span>
+              </a>
+              <a href="#" class="umd-sans-larger umd-slidein-underline-gold">
+                <span>UMD Slidein Underline Gold</span>
+              </a>
+              <a href="#" class="umd-sans-larger umd-slidein-underline-black">
+                <span>UMD Slidein Underline Black</span>
+              </a>
+              <div class="p-xs bg-black text-white">
+                <a href="#" class="umd-sans-larger umd-slidein-underline-white">
+                  <span>UMD Slidein Underline White</span>
+                </a>
+              </div>
+            </div>
+
+            <h3 class="my-md umd-sans-small font-bold text-gray-mediumAA">
+              Fade-in Animations
+            </h3>
+
+            <div class="flex flex-col items-start gap-y-sm">
+              <a href="#" class="umd-sans-larger umd-fadein-underline-red">
+                <span>UMD Fadein Underline Red</span>
+              </a>
+              <a href="#" class="umd-sans-larger umd-fadein-underline-gold">
+                <span>UMD Fadein Underline Gold</span>
+              </a>
+              <a href="#" class="umd-sans-larger umd-fadein-underline-black">
+                <span>UMD Fadein Underline Black</span>
+              </a>
+              <a href="#" class="umd-sans-larger umd-fadein-underline-gray">
+                <span>UMD Fadein Underline Gray</span>
+              </a>
+              <div class="p-xs bg-black text-white">
+                <a href="#" class="umd-sans-larger umd-fadein-underline-white">
+                  <span>UMD Fadein Underline White</span>
+                </a>
+              </div>
+            </div>
+
+            <h3 class="my-md umd-sans-small font-bold text-gray-mediumAA">
+              Special Animations
+            </h3>
+
+            <div class="flex flex-col items-start gap-y-sm">
+              <a href="#"
+                class="umd-sans-larger umd-slidein-underline-gray-red">
+                <span>UMD Fadein Underline Gray to Red</span>
+              </a>
+
+              <div>
+                <p class="bg-black p-sm text-white">
+                  Class for use on simple links <em>
+                    (links without any child nodes)
+                  </em>:
+                  <a href="#" class="umd-fadein-simple-dark">
+                    Use <code>.umd-fadein-simple-dark</code> On the link itself
+                  </a>
+                </p>
+              </div>
+              <div class="umd-rich-text umd-rich-text-dark bg-black p-sm text-white">
+                <p>
+                  For links in <a href="#">rich text elements</a> on a dark background.
+                  Use <span class="font-mono">.umd-rich-text-dark</span>
+                </p>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
Realizing with the card styles moving these from provost into the configuration would be helpful, especially since our team uses them all over the place.

Added examples to the kitchen sink and deployed to staging: https://kitchen-sink.umd-staging.com/configuration#link-animations

_Once this is merged in, I can make some additions to the card/overlay-card light-DOM styles._

https://github.com/UMD-Digital/design-system/assets/5532234/b1a8f207-5ca8-4e59-9675-e43fec8933d3

