### PR TITLE
Fixes DSYS-211: Remove sans-smaller on rich text blocks in overlay card examples

### DIFF
--- a/packages/kitchen-sink/source/twig/components/card-overlay.twig
+++ b/packages/kitchen-sink/source/twig/components/card-overlay.twig
@@ -185,7 +185,7 @@
             <h3 class="umd-sans-larger">
               Lorem ipsum dolor
             </h3>
-            <div class="umd-rich-text umd-sans-smaller">
+            <div class="umd-rich-text">
               <p>
                 Nunc vulputate libero et velit interdum, ac aliquet odio mattis.
               </p>
@@ -204,7 +204,7 @@
             <h3 class="umd-sans-larger">
               Lorem ipsum dolor
             </h3>
-            <div class="umd-rich-text umd-sans-smaller">
+            <div class="umd-rich-text">
               <p>
                 Nunc vulputate libero et velit interdum, ac aliquet odio mattis.
               </p>
@@ -229,7 +229,7 @@
                 </span>
               </a>
             </h3>
-            <div class="umd-rich-text umd-sans-smaller">
+            <div class="umd-rich-text">
               <p>
                 Nunc vulputate libero et velit interdum, ac aliquet odio mattis.
               </p>
@@ -292,7 +292,7 @@
                 <span>Lorem ipsum dolor</span>
               </a>
             </h3>
-            <div class="umd-rich-text umd-sans-smaller">
+            <div class="umd-rich-text">
               <p>
                 Nunc vulputate libero et velit interdum, ac aliquet odio mattis.
               </p>
@@ -320,7 +320,7 @@
               </a>
             </h3>
 
-            <div class="umd-rich-text umd-sans-smaller">
+            <div class="umd-rich-text">
               <p>
                 Nunc vulputate libero et velit interdum, ac aliquet odio mattis.
               </p>
@@ -344,7 +344,7 @@
               </a>
             </h3>
 
-            <div class="umd-rich-text umd-sans-smaller">
+            <div class="umd-rich-text">
               <p>
                 Nunc vulputate libero et velit interdum, ac aliquet odio mattis.
               </p>
@@ -589,7 +589,7 @@
                 <span>Lorem ipsum dolor</span>
               </a>
             </h3>
-            <div class="umd-rich-text umd-sans-smaller">
+            <div class="umd-rich-text">
               <p>
                 Nunc vulputate libero et velit interdum, ac aliquet odio mattis.
               </p>
@@ -681,7 +681,7 @@
                 <span>Lorem ipsum dolor</span>
               </a>
             </h3>
-            <div class="umd-rich-text umd-sans-smaller">
+            <div class="umd-rich-text">
               <p>
                 Nunc vulputate libero et velit interdum, ac aliquet odio mattis.
               </p>


### PR DESCRIPTION
https://linear.app/umd-web-services/issue/DSYS-211/overlay-card-default-styles#comment-dbc6705c