### PR TITLE
Update carousel card lightDOM styles

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/umd-web-components",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "UMD Web Components",
   "main": "dist/bundle.js",
   "module": "dist/index.js",

--- a/packages/components/source/components/carousel-cards/styles/light-dom.css
+++ b/packages/components/source/components/carousel-cards/styles/light-dom.css
@@ -3,8 +3,7 @@ umd-element-carousel-cards {
     @apply umd-rich-text-dark;
   }
 
-  & .umd-rich-text a:hover,
-  & .umd-rich-text a:focus {
-    color: theme(colors.gold);
+  & .umd-cta-secondary {
+    color: theme(colors.white);
   }
 }

--- a/packages/kitchen-sink/source/styles/elements/carousel-cards.css
+++ b/packages/kitchen-sink/source/styles/elements/carousel-cards.css
@@ -6,17 +6,6 @@ umd-element-carousel-cards:not(:defined) {
   margin-top: theme('spacing.2xl');
 }
 
-umd-element-carousel-cards {
-  & .umd-cta-secondary {
-    color: theme(colors.white);
-  }
-
-  & .umd-aligned-content > * {
-    text-wrap: pretty;
-    margin-top: theme(spacing.md);
-  }
-}
-
 umd-card {
   display: block;
   position: relative;


### PR DESCRIPTION
- Add light color override for carousel cards cta slot on secondary type cta links
- Rebased main, and tested locally before making this PR.
- Fixes [DSYS-236](https://linear.app/umd-web-services/issue/DSYS-236/refactor-for-slots-with-default-styling)