### PR TITLE
Add simple animated link styles for light theme

### DIFF
--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/umd-web-configuration",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "UMD Design System Tokens and Common Classes by the Web Services Team in the Office of Marketing and Communications",
   "main": "dist/index.js",
   "author": "UMD Web Services <digital@umd.edu>",

--- a/packages/configuration/source/common/animated-links.ts
+++ b/packages/configuration/source/common/animated-links.ts
@@ -172,6 +172,24 @@ const specialAnimations = {
       textDecoration: 'none',
     },
   },
+
+  '.umd-fadein-simple-light': {
+    ...baseLink,
+    backgroundImage: `linear-gradient(currentColor, currentColor)`,
+    backgroundPosition: 'left calc(100% - 2px)',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: '100% 1px',
+    color: 'currentColor',
+    transition: 'color 0.5s, background-image 0.5s, background-position 0.5s',
+
+    [`&:hover,
+    &:focus`]: {
+      backgroundImage: `linear-gradient(${colors.red}, ${colors.red})`,
+      backgroundPosition: 'left calc(100%)',
+      color: colors.red,
+      textDecoration: 'none',
+    },
+  },
 };
 
 const animatedLinks = Object.assign(


### PR DESCRIPTION
It's not used anywhere, but added these class for you to use in the components _(if needed)_. Light uses the text's current color, and changes to red with a red underline on hover/focus.

Light theme simple animation
https://github.com/UMD-Digital/design-system/assets/5532234/fb623a0a-6e71-4eaa-a1a5-9075bcdd4417

to match the dark theme simple animation:
https://github.com/UMD-Digital/design-system/assets/5532234/af90daf1-f586-4351-ba62-eae1d1e78a5b

Changes have been published to [the configuration `0.1.9`](https://www.npmjs.com/package/@universityofmaryland/umd-web-configuration)