### PR TITLE
Close DSYS-239: Refactor Rich Text configuration

### DIFF
--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/umd-web-configuration",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "UMD Design System Tokens and Common Classes by the Web Services Team in the Office of Marketing and Communications",
   "main": "dist/index.js",
   "author": "UMD Web Services <digital@umd.edu>",

--- a/packages/configuration/source/common/rich-text-lists.ts
+++ b/packages/configuration/source/common/rich-text-lists.ts
@@ -784,10 +784,12 @@ const orderedListStyleTypes = {
   },
 };
 
-const richTextlists = {
-  ...listStylesBase,
-  ...unOrderedListStyleTypes,
-  ...orderedListStyleTypes,
+const richTextLists = {
+  '.umd-rich-text-lists': {
+    ...listStylesBase,
+    ...unOrderedListStyleTypes,
+    ...orderedListStyleTypes,
+  },
 };
 
-export { richTextlists };
+export { richTextLists };

--- a/packages/configuration/source/common/rich-text.ts
+++ b/packages/configuration/source/common/rich-text.ts
@@ -3,138 +3,146 @@ import { fontFamily, fontWeight } from '../tokens/fonts';
 import { spacing } from '../tokens/layout';
 import { icons } from '../assets/icons';
 import { typography } from './typography';
-import { richTextlists } from './rich-text-lists';
+import { richTextLists } from './rich-text-lists';
 import { animatedLinks } from '../common/animated-links';
 
 const richTextBase = {
-  '& > *': {
-    marginTop: spacing.md,
+  '.umd-rich-text-base': {
+    '& > *': {
+      marginTop: spacing.md,
 
-    '&:first-child': {
-      marginTop: '0',
+      '&:first-child': {
+        marginTop: '0',
+      },
     },
-  },
 
-  [`& p,
+    [`& p,
     & ul,
     & ol,
     & pre,
     & blockquote`]: {
-    maxWidth: '960px',
-  },
+      maxWidth: '960px',
+    },
 
-  '& hr': {
-    border: 'none',
-    height: '1px',
-    backgroundColor: 'currentColor',
-  },
+    '& hr': {
+      border: 'none',
+      height: '1px',
+      backgroundColor: 'currentColor',
+    },
 
-  '& em, & i': {
-    fontStyle: 'italic',
-  },
+    '& em, & i': {
+      fontStyle: 'italic',
+    },
 
-  '& strong, & b ': {
-    fontWeight: fontWeight.black,
-  },
+    '& strong, & b': {
+      fontWeight: fontWeight.black,
+    },
 
-  '& u ': {
-    textDecoration: 'underline',
-  },
+    '& u': {
+      textDecoration: 'underline',
+    },
 
-  '& a ': {
-    color: 'currentColor',
-    textDecoration: 'underline',
-    transition: 'color 0.5s',
+    '& a': {
+      color: 'currentColor',
+      textDecoration: 'underline',
+      transition: 'color 0.5s',
 
-    '&:hover, &:focus': {
-      color: colors.red,
+      '&:hover, &:focus': {
+        color: colors.red,
+      },
+    },
+
+    '& img': {
+      maxWidth: '100%',
     },
   },
-
-  '& img': {
-    maxWidth: '100%',
-  },
 };
 
-const coding = {
-  '& code, & pre': {
-    border: `1px solid ${colors.gray.lightest}`,
-    backgroundColor: colors.gray.lightest,
-    borderRadius: '3px',
-    color: 'currentColor',
-    fontFamily: fontFamily.mono,
-  },
+const richTextCoding = {
+  '.umd-rich-text-coding': {
+    '& code, & pre': {
+      border: `1px solid ${colors.gray.lightest}`,
+      backgroundColor: colors.gray.lightest,
+      borderRadius: '3px',
+      color: 'currentColor',
+      fontFamily: fontFamily.mono,
+    },
 
-  '& code': {
-    display: 'inline-block',
-    padding: `0 ${spacing.min}`,
-  },
-
-  '& pre': {
-    padding: spacing.min,
-  },
-};
-
-const blockquotes = {
-  '& blockquote': {
-    ...typography['.umd-sans-larger'],
-    ...{
+    '& code': {
       display: 'inline-block',
-      borderLeft: `2px solid ${colors.red}`,
-      position: 'relative',
-      paddingLeft: spacing.md,
+      padding: `0 ${spacing.min}`,
+    },
 
-      '&:before': {
-        content: '""',
-        backgroundImage: `url('${icons.quoteRed}')`,
-        backgroundSize: 'contain',
-        backgroundPosition: 'center',
-        position: 'absolute',
-        top: '0',
-        left: '-40px',
-        height: '30px',
-        width: '30px',
+    '& pre': {
+      padding: spacing.min,
+    },
+  },
+};
+
+const richTextQuotes = {
+  '.umd-rich-text-inline-quote': {
+    '& blockquote': {
+      ...typography['.umd-sans-larger'],
+      ...{
+        display: 'inline-block',
+        borderLeft: `2px solid ${colors.red}`,
+        position: 'relative',
+        paddingLeft: spacing.md,
+
+        '&:before': {
+          content: '""',
+          backgroundImage: `url('${icons.quoteRed}')`,
+          backgroundSize: 'contain',
+          backgroundPosition: 'center',
+          position: 'absolute',
+          top: '0',
+          left: '-40px',
+          height: '30px',
+          width: '30px',
+        },
       },
     },
   },
 };
 
-const tables = {
-  '& table': {
-    borderCollapse: 'collapse',
-    display: 'block',
-    overflowX: 'auto',
-    tableLayout: 'fixed',
-    maxWidth: '100%',
+const richTextTables = {
+  '.umd-rich-text-inline-table': {
+    '& table': {
+      borderCollapse: 'collapse',
+      display: 'block',
+      overflowX: 'auto',
+      tableLayout: 'fixed',
+      maxWidth: '100%',
 
-    '& th': typography['.umd-sans-large'],
-    '& td': typography['.umd-sans-smaller'],
+      '& th': typography['.umd-sans-large'],
+      '& td': typography['.umd-sans-smaller'],
 
-    '& th, & td': {
-      padding: `${spacing.lg} ${spacing.md}`,
-      verticalAlign: 'top',
+      '& th, & td': {
+        padding: `${spacing.lg} ${spacing.md}`,
+        verticalAlign: 'top',
 
-      '&:first-child': {
-        paddingLeft: spacing.lg,
+        '&:first-child': {
+          paddingLeft: spacing.lg,
+        },
+
+        '&:last-Child': {
+          paddingRight: spacing.lg,
+        },
       },
 
-      '&:last-Child': {
-        paddingRight: spacing.lg,
+      '& thead th': {
+        background: colors.gray.lighter,
+        color: colors.black,
+        textAlign: 'left',
       },
-    },
 
-    '& thead th': {
-      background: colors.gray.lighter,
-      color: colors.black,
-      textAlign: 'left',
-    },
+      '& tbody tr': {
+        borderTop: `1px solid ${colors.gray.light}`,
+      },
 
-    '& tbody tr': {
-      borderTop: `1px solid ${colors.gray.light}`,
-    },
-
-    '& tr:nth-child(even)': {
-      background: colors.gray.lightest,
+      '& tr:nth-child(even)': {
+        background: colors.gray.lightest,
+      },
     },
   },
 };
@@ -143,12 +151,13 @@ const richText = {
   '.umd-rich-text': {
     fontWeight: fontWeight.medium,
 
-    ...richTextBase,
-    ...coding,
-    ...blockquotes,
-    ...tables,
-    ...richTextlists,
+    ...richTextBase['.umd-rich-text-base'],
+    ...richTextCoding['.umd-rich-text-coding'],
+    ...richTextQuotes['.umd-rich-text-inline-quote'],
+    ...richTextTables['.umd-rich-text-inline-table'],
+    ...richTextLists['.umd-rich-text-lists'],
   },
+
   '.umd-rich-text-dark': {
     color: colors.white,
 
@@ -158,4 +167,11 @@ const richText = {
   },
 };
 
-export { richText };
+export {
+  richText,
+  richTextBase,
+  richTextCoding,
+  richTextQuotes,
+  richTextTables,
+  richTextLists,
+};

--- a/packages/configuration/source/index.ts
+++ b/packages/configuration/source/index.ts
@@ -12,7 +12,14 @@ import { root } from './dependancies/root';
 import { skipContent, screenReaderOnly } from './common/accessibility';
 import { typography } from './common/typography';
 import { animatedLinks } from './common/animated-links';
-import { richText } from './common/rich-text';
+import {
+  richText,
+  richTextBase,
+  richTextCoding,
+  richTextQuotes,
+  richTextTables,
+  richTextLists,
+} from './common/rich-text';
 import { umdFlexGrid } from './layout/umd-flex';
 import { umdGrid } from './layout/umd-grid';
 import { umdLock } from './layout/umd-lock';
@@ -59,6 +66,11 @@ export {
   screenReaderOnly,
   skipContent,
   richText,
+  richTextBase,
+  richTextCoding,
+  richTextQuotes,
+  richTextTables,
+  richTextLists,
   typography,
   animatedLinks,
   umdGrid,


### PR DESCRIPTION
- Create and export Rich Text styles as separate smaller objects for web components
- Each "part" can be called individually, and combined as needed. See Example.
- Changes have been published to [npm `0.1.10`](https://www.npmjs.com/package/@universityofmaryland/umd-web-configuration)

Example:
```js
import { richTextBase, richTextLists } from '@universityofmaryland/umd-web-configuration';

const richTextForComponent = {
  ".umd-my-custom-richt-text-class": {
    ...richTextBase['.umd-rich-text-base'],
    ...richTextLists['.umd-rich-text-lists'],
  },
};
```