### PR TITLE
Close DSYS-455: Set animated-link background-position to match the deprecated class based cta styles

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/theme",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A configuration of the tokens and other styles from UMD Design system for use with CSS frameworks that support JSS (CSS-in-JS).",
   "keywords": [],
   "author": "UMD Web Services <digital@umd.edu>",

--- a/packages/variables/package.json
+++ b/packages/variables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/variables",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Base tokens, variables, and classes for use in the University of Maryland Design System",
   "main": "dist/index.js",
   "author": "UMD Web Services <digital@umd.edu>",

--- a/packages/variables/source/styles/common/animated-links.ts
+++ b/packages/variables/source/styles/common/animated-links.ts
@@ -3,7 +3,7 @@ import { colors } from '../../tokens/colors';
 const baseSpan = {
   display: 'inline',
   position: 'relative',
-  backgroundPosition: 'left calc(100% - 0.125em)',
+  backgroundPosition: 'left bottom',
   backgroundRepeat: 'no-repeat',
   transition: 'background 0.5s',
 };
@@ -157,6 +157,7 @@ const specialAnimations = {
 
   '.umd-fadein-simple-dark': {
     ...baseLink,
+
     backgroundImage: `linear-gradient(${colors.white}, ${colors.white})`,
     backgroundPosition: 'left calc(100% - 2px)',
     backgroundRepeat: 'no-repeat',
@@ -175,6 +176,7 @@ const specialAnimations = {
 
   '.umd-fadein-simple-light': {
     ...baseLink,
+
     backgroundImage: `linear-gradient(currentColor, currentColor)`,
     backgroundPosition: 'left calc(100% - 2px)',
     backgroundRepeat: 'no-repeat',
@@ -196,6 +198,7 @@ const animatedLinks = Object.assign(
   slideInUnderline,
   fadeInUnderline,
   specialAnimations,
+  baseAnimation,
 );
 
 export { animatedLinks };


### PR DESCRIPTION
- Changes effect the variables and theme, updated version numbers for both (only the theme can be published).
- I'll publish once changes are approved.
- **Note:** Changes will effect web components that use animated-link styles when they're next updated _(ie: call to action element)_. I haven't touched version numbers on that package.

**Animated Links Styles:**
<img width="883" alt="Screenshot 2024-01-22 at 1 05 14 PM" src="https://github.com/UMD-Digital/design-system/assets/5532234/ecc3abe9-654a-459d-bd71-ea0eaea92ac3">

**Call to Action Element Examples:**
<img width="902" alt="Screenshot 2024-01-22 at 1 13 09 PM" src="https://github.com/UMD-Digital/design-system/assets/5532234/73f14c5c-7bee-4288-b17f-bc11d26c85f3">
_*Before styles assume the `backgroun-position: left bottom !important;` styles have been removed._