### PR TITLE
Close DSYS-508: Set list item vertical spacing to 16px

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/theme",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A configuration of the tokens and other styles from UMD Design system for use with CSS frameworks that support JSS (CSS-in-JS).",
   "keywords": [],
   "author": "UMD Web Services <digital@umd.edu>",

--- a/packages/variables/package.json
+++ b/packages/variables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/variables",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Base tokens, variables, and classes for use in the University of Maryland Design System",
   "main": "dist/index.js",
   "author": "UMD Web Services <digital@umd.edu>",

--- a/packages/variables/source/styles/common/rich-text-lists.ts
+++ b/packages/variables/source/styles/common/rich-text-lists.ts
@@ -74,7 +74,7 @@ const listStylesBase = {
   },
 
   '& li': {
-    marginTop: spacing.md,
+    marginTop: spacing.sm,
 
     '&:first-child': {
       marginTop: '0',
@@ -82,7 +82,7 @@ const listStylesBase = {
 
     [`& > ul,
       & > ol`]: {
-      marginTop: spacing.md,
+      marginTop: spacing.sm,
     },
   },
 };


### PR DESCRIPTION
Slight change made to the variables and theme to fix inconsistencies found in [DSYS-487](https://linear.app/umd-web-services/issue/DSYS-487/cms-intergration). Changes already published on the theme module.

 I haven't touched or tested this on the components, but it _shouldn't_ effect them. Changes pushed to the [kitchen sink](https://kitchen-sink.umd-staging.com/variables/rich-text)