### PR TITLE
Close MEV-125: Section Intro Wide

### DIFF
--- a/packages/kitchen-sink/source/twig/theme/layout/section-intro.twig
+++ b/packages/kitchen-sink/source/twig/theme/layout/section-intro.twig
@@ -58,5 +58,23 @@
         </div>
       </div>
     </umd-component-intro>
+
+    <div class="umd-sans-large type-hr">
+      <span class="type">Section Intro</span>
+      <span class="type-detail">Wide</span>
+    </div>
+
+    <umd-component-intro-wide>
+      <div class="intro-content-wrapper">
+        <h2 class="umd-sans-largest">
+          FROM MARYLAND TODAY
+        </h2>
+        <div class="umd-layout-flex-row-auto">
+          <umd-element-call-to-action type="secondary">
+            <a href="/"><span>See all election related content</span></a>
+          </umd-element-call-to-action>
+        </div>
+      </div>
+    </umd-component-intro-wide>
   </div>
 {% endblock %}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofmaryland/theme",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "A configuration of the tokens and other styles from UMD Design system for use with CSS frameworks that support JSS (CSS-in-JS).",
   "keywords": [],
   "author": "UMD Web Services <digital@umd.edu>",

--- a/packages/theme/source/components/intro.ts
+++ b/packages/theme/source/components/intro.ts
@@ -2,11 +2,13 @@ import {
   spacing,
   colors,
   umdAlignedContent,
+  queries,
 } from '@universityofmaryland/variables';
 
 const umdIntro = {
   'umd-component-intro': {
-    container: 'umd-intro inline-size',
+    containerName: 'umd-component-intro',
+    containerType: 'inline-size',
     display: 'block',
 
     '& .intro-content-wrapper': {
@@ -29,7 +31,11 @@ const umdIntro = {
     },
   },
 
-  '.umd-intro-type-simple': {
+  'umd-component-intro-simple': {
+    containerName: 'umd-component-intro',
+    containerType: 'inline-size',
+    display: 'block',
+
     '& .intro-content-wrapper': {
       paddingTop: '0',
 
@@ -39,12 +45,16 @@ const umdIntro = {
     },
   },
 
-  '.umd-intro-type-wide': {
+  'umd-component-intro-wide': {
+    containerName: 'umd-component-intro',
+    containerType: 'inline-size',
+    display: 'block',
+
     '& .intro-content-wrapper': {
       display: 'block',
-      paddingTop: '0',
+      padding: '0',
 
-      '@container umd-intro (min-width: 640px)': {
+      [`@container umd-component-intro (${queries.large.min})`]: {
         alignItems: 'center',
         display: 'flex',
         justifyContent: 'space-between',
@@ -59,21 +69,22 @@ const umdIntro = {
         maxWidth: '100%',
         marginTop: spacing.xs,
 
-        '@container umd-intro (min-width: 640px)': {
+        [`@container umd-component-intro (${queries.large.min})`]: {
           marginTop: '0',
         },
 
         '&:first-child': {
           marginTop: '0',
           marginRight: spacing.md,
+          paddingBottom: '0',
 
-          '@container umd-intro (min-width: 640px)': {
+          [`@container umd-component-intro (${queries.large.min})`]: {
             maxWidth: '66.666%',
           },
         },
 
         '&:last-child': {
-          '@container umd-intro (min-width: 640px)': {
+          [`@container umd-component-intro (${queries.large.min})`]: {
             maxWidth: '33.333%',
           },
         },


### PR DESCRIPTION
- Update Section Intro container queries to work in theme

- Theme update to version 0.0.6

[On Provost](https://github.com/UMD-Digital/provost/blob/main/source/styles/common/elements/umd-intro.css): this is the container of: `<umd-intro data-type="wide">`
Requesting update naming for this component in Theme: `<umd-component-intro-wide>`

- Removed padding from `.intro-content-wrapper` within `<umd-component-intro-wide>` to help with alignment of the content - let me know if there is a different way you would prefer to handle this

[Updated Staging to View Section Intro Wide](https://kitchen-sink.umd-staging.com/theme/layout/section-intro)