### PR TITLE
Update kitchen sink heading styles

### DIFF
--- a/packages/kitchen-sink/source/styles/dependencies/kitchen-sink-styles.css
+++ b/packages/kitchen-sink/source/styles/dependencies/kitchen-sink-styles.css
@@ -1,8 +1,12 @@
-.umd-sans-largest {
+.page-heading {
+  @apply umd-sans-largest;
+
   padding-bottom: 40px;
 }
 
-.umd-sans-large {
+.content-heading {
+  @apply umd-sans-large;
+
   display: block;
   padding: 45px 0 15px 0;
   position: relative;

--- a/packages/kitchen-sink/source/twig/components/alert.twig
+++ b/packages/kitchen-sink/source/twig/components/alert.twig
@@ -6,11 +6,11 @@
 {% block page %}
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Alert
       </h1>
 
-      <h2 class="umd-sans-large">
+      <h2 class="content-heading">
         Content Variations
       </h2>
 
@@ -18,7 +18,7 @@
 
       <div id="content-succinct" class="dropdown-selection" aria-hidden="true">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
 
@@ -34,7 +34,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Notification</span>
           </div>
@@ -51,7 +51,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Emergency</span>
           </div>
@@ -68,7 +68,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>
@@ -81,7 +81,7 @@
 
       <div id="content-normal" class="dropdown-selection" aria-hidden="false">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
 
@@ -97,7 +97,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Notification</span>
           </div>
@@ -114,7 +114,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Emergency</span>
           </div>
@@ -131,7 +131,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>
@@ -144,7 +144,7 @@
 
       <div id="content-verbose" class="dropdown-selection" aria-hidden="true">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
 
@@ -160,7 +160,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Notification</span>
           </div>
@@ -177,7 +177,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Emergency</span>
           </div>
@@ -194,7 +194,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>

--- a/packages/kitchen-sink/source/twig/components/call-to-action-button.twig
+++ b/packages/kitchen-sink/source/twig/components/call-to-action-button.twig
@@ -6,11 +6,11 @@
 {% block page %}
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Call to Action (Button)
       </h1>
 
-      <h2 class="umd-sans-large">
+      <h2 class="content-heading">
         Content Variations
       </h2>
 
@@ -20,7 +20,7 @@
   <div id="content-succinct" class="dropdown-selection" aria-hidden="true">
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Primary Styling
         </p>
         {{
@@ -36,7 +36,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -56,7 +56,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -74,7 +74,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Secondary Styling
         </p>
 
@@ -91,7 +91,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -110,7 +110,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -130,7 +130,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Outline Styling
         </p>
 
@@ -147,7 +147,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -166,7 +166,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -189,7 +189,7 @@
   <div id="content-normal" class="dropdown-selection" aria-hidden="false">
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Primary Styling
         </p>
         {{
@@ -205,7 +205,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -225,7 +225,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -243,7 +243,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Secondary Styling
         </p>
 
@@ -260,7 +260,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -279,7 +279,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -299,7 +299,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Outline Styling
         </p>
 
@@ -316,7 +316,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -335,7 +335,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -357,7 +357,7 @@
   <div id="content-verbose" class="dropdown-selection" aria-hidden="true">
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Primary Styling
         </p>
         {{
@@ -373,7 +373,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -393,7 +393,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -411,7 +411,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Secondary Styling
         </p>
 
@@ -428,7 +428,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -447,7 +447,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -467,7 +467,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Outline Styling
         </p>
 
@@ -484,7 +484,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="theme">Outline Styling</span>
           <span class="type-detail">Icon Example</span>
         </p>
@@ -503,7 +503,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>

--- a/packages/kitchen-sink/source/twig/components/call-to-action.twig
+++ b/packages/kitchen-sink/source/twig/components/call-to-action.twig
@@ -6,11 +6,11 @@
 {% block page %}
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Call to Action
       </h1>
 
-      <h2 class="umd-sans-large">
+      <h2 class="content-heading">
         Content Variations
       </h2>
 
@@ -20,7 +20,7 @@
   <div id="content-succinct" class="dropdown-selection" aria-hidden="true">
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Primary Styling
         </p>
         {{
@@ -36,7 +36,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Icon options</span>
         </p>
@@ -72,7 +72,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -108,7 +108,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Secondary Styling
         </p>
 
@@ -125,7 +125,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Icon options</span>
         </p>
@@ -160,7 +160,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -195,7 +195,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Outline Styling
         </p>
 
@@ -211,7 +211,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Icon Options</span>
         </p>
@@ -244,7 +244,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -280,7 +280,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Combo
         </p>
 
@@ -307,7 +307,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Combo</span>
           <span class="type-detail">Primary with Plain Text Slot</span>
         </p>
@@ -327,7 +327,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Combo</span>
           <span class="type-detail">Secondary with Plain Text Slot</span>
         </p>
@@ -346,7 +346,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Primary Styling</span>
         </p>
@@ -365,7 +365,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Secondary Styling</span>
         </p>
@@ -384,7 +384,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Outline Styling</span>
         </p>
@@ -405,7 +405,7 @@
   <div id="content-normal" class="dropdown-selection" aria-hidden="false">
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Primary Styling
         </p>
         {{
@@ -419,7 +419,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Icon options</span>
         </p>
@@ -455,7 +455,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -491,7 +491,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Secondary Styling
         </p>
 
@@ -508,7 +508,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Icon options</span>
         </p>
@@ -543,7 +543,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -578,7 +578,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Outline Styling
         </p>
 
@@ -594,7 +594,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Icon Options</span>
         </p>
@@ -627,7 +627,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -663,7 +663,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Combo
         </p>
 
@@ -690,7 +690,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Combo</span>
           <span class="type-detail">Primary with Plain Text Slot</span>
         </p>
@@ -710,7 +710,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Combo</span>
           <span class="type-detail">Secondary with Plain Text Slot</span>
         </p>
@@ -729,7 +729,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Primary Styling</span>
         </p>
@@ -748,7 +748,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Secondary Styling</span>
         </p>
@@ -767,7 +767,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Outline Styling</span>
         </p>
@@ -788,7 +788,7 @@
   <div id="content-verbose" class="dropdown-selection" aria-hidden="true">
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Primary Styling
         </p>
         {{
@@ -804,7 +804,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Icon options</span>
         </p>
@@ -840,7 +840,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Primary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -876,7 +876,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Secondary Styling
         </p>
 
@@ -893,7 +893,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Icon options</span>
         </p>
@@ -928,7 +928,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Secondary Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -963,7 +963,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Outline Styling
         </p>
 
@@ -979,7 +979,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Icon Options</span>
         </p>
@@ -1012,7 +1012,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Outline Styling</span>
           <span class="type-detail">Sized Large</span>
         </p>
@@ -1048,7 +1048,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           Combo
         </p>
 
@@ -1075,7 +1075,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Combo</span>
           <span class="type-detail">Primary with Plain Text Slot</span>
         </p>
@@ -1095,7 +1095,7 @@
 
     <section>
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr">
+        <p class="content-heading type-hr">
           <span class="type">Combo</span>
           <span class="type-detail">Secondary with Plain Text Slot</span>
         </p>
@@ -1114,7 +1114,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Primary Styling</span>
         </p>
@@ -1133,7 +1133,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Secondary Styling</span>
         </p>
@@ -1152,7 +1152,7 @@
 
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
-        <p class="umd-sans-large type-hr" style="color: white">
+        <p class="content-heading type-hr" style="color: white">
           <span class="type">Theme Dark</span>
           <span class="type-detail">Outline Styling</span>
         </p>

--- a/packages/kitchen-sink/source/twig/components/card-overlay.twig
+++ b/packages/kitchen-sink/source/twig/components/card-overlay.twig
@@ -14,11 +14,11 @@
 
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Overlay Card
       </h1>
 
-      <h2 class="umd-sans-large">
+      <h2 class="content-heading">
         Content Variations
       </h2>
 
@@ -26,7 +26,7 @@
 
       <div id="content-succinct" class="dropdown-selection" aria-hidden="true">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
           <div class="umd-grid-three my-md">
@@ -40,7 +40,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>
@@ -58,7 +58,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Optional Date</span>
           </div>
@@ -74,7 +74,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">CTA Icons</span>
           </div>
@@ -105,7 +105,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Dark</span>
           </div>
@@ -121,7 +121,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Light</span>
           </div>
@@ -136,7 +136,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">
               Grid Configuration Animation Grouping (3)
@@ -165,7 +165,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">
               Grid Configuration Animation Grouping (4)
@@ -200,7 +200,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (3)</span>
           </div>
@@ -227,7 +227,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (4)</span>
           </div>
@@ -260,7 +260,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (2)</span>
           </div>
@@ -283,7 +283,7 @@
 
       <div id="content-normal" class="dropdown-selection" aria-hidden="false">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
           <div class="umd-grid-three my-md">
@@ -297,7 +297,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>
@@ -315,7 +315,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Optional Date</span>
           </div>
@@ -330,7 +330,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">CTA Icons</span>
           </div>
@@ -361,7 +361,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Dark</span>
           </div>
@@ -377,7 +377,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Light</span>
           </div>
@@ -393,7 +393,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">
               Grid Configuration Animation Grouping (3)
@@ -422,7 +422,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">
               Grid Configuration Animation Grouping (4)
@@ -457,7 +457,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (3)</span>
           </div>
@@ -484,7 +484,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (4)</span>
           </div>
@@ -517,7 +517,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (2)</span>
           </div>
@@ -540,7 +540,7 @@
 
       <div id="content-verbose" class="dropdown-selection" aria-hidden="true">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
           <div class="umd-grid-three my-md">
@@ -554,7 +554,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>
@@ -572,7 +572,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Optional Date</span>
           </div>
@@ -587,7 +587,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">CTA Icons</span>
           </div>
@@ -618,7 +618,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Dark</span>
           </div>
@@ -634,7 +634,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Light</span>
           </div>
@@ -650,7 +650,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">
               Grid Configuration Animation Grouping (3)
@@ -679,7 +679,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">
               Grid Configuration Animation Grouping (4)
@@ -714,7 +714,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (3)</span>
           </div>
@@ -741,7 +741,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (4)</span>
           </div>
@@ -774,7 +774,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (2)</span>
           </div>

--- a/packages/kitchen-sink/source/twig/components/card.twig
+++ b/packages/kitchen-sink/source/twig/components/card.twig
@@ -11,11 +11,11 @@
 
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Standard Card
       </h1>
 
-      <h2 class="umd-sans-large">
+      <h2 class="content-heading">
         Content Variations
       </h2>
 
@@ -23,7 +23,7 @@
 
       <div id="content-succinct" class="dropdown-selection" aria-hidden="true">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
@@ -39,7 +39,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Outlined</span>
           </div>
@@ -56,7 +56,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Aligned</span>
           </div>
@@ -73,7 +73,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>
@@ -93,7 +93,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Optional Date</span>
           </div>
@@ -109,7 +109,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Minimal</span>
           </div>
@@ -129,7 +129,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Dark</span>
           </div>
@@ -146,7 +146,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (3)</span>
           </div>
@@ -182,7 +182,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (4)</span>
           </div>
@@ -219,7 +219,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (2)</span>
           </div>
@@ -248,7 +248,7 @@
 
       <div id="content-normal" class="dropdown-selection" aria-hidden="false">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
@@ -262,7 +262,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Outlined</span>
           </div>
@@ -279,7 +279,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Aligned</span>
           </div>
@@ -296,7 +296,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>
@@ -315,7 +315,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Optional Date</span>
           </div>
@@ -332,7 +332,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Minimal</span>
           </div>
@@ -352,7 +352,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Dark</span>
           </div>
@@ -368,7 +368,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (3)</span>
           </div>
@@ -404,7 +404,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (4)</span>
           </div>
@@ -441,7 +441,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (2)</span>
           </div>
@@ -470,7 +470,7 @@
 
       <div id="content-verbose" class="dropdown-selection" aria-hidden="true">
         <section>
-          <h3 class="umd-sans-large type-hr">
+          <h3 class="content-heading type-hr">
             Default
           </h3>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
@@ -484,7 +484,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Type</span>
             <span class="type-detail">Outlined</span>
           </div>
@@ -501,7 +501,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Aligned</span>
           </div>
@@ -518,7 +518,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Required Only</span>
           </div>
@@ -537,7 +537,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Optional Date</span>
           </div>
@@ -554,7 +554,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Field Options</span>
             <span class="type-detail">Minimal</span>
           </div>
@@ -574,7 +574,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Theme</span>
             <span class="type-detail">Dark</span>
           </div>
@@ -590,7 +590,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (3)</span>
           </div>
@@ -626,7 +626,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (4)</span>
           </div>
@@ -663,7 +663,7 @@
         </section>
 
         <section>
-          <div class="umd-sans-large type-hr">
+          <div class="content-heading type-hr">
             <span class="type">Layout</span>
             <span class="type-detail">Grouping (2)</span>
           </div>

--- a/packages/kitchen-sink/source/twig/components/carousel-cards.twig
+++ b/packages/kitchen-sink/source/twig/components/carousel-cards.twig
@@ -15,11 +15,11 @@
 
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Carousel Cards
       </h1>
 
-      <h2 class="umd-sans-large">
+      <h2 class="content-heading">
         Content Variations
       </h2>
 
@@ -29,7 +29,7 @@
 
   <div id="content-succinct" class="dropdown-selection" aria-hidden="true">
     <div class="umd-lock">
-      <h3 class="umd-sans-large type-hr">
+      <h3 class="content-heading type-hr">
         Default
       </h3>
     </div>
@@ -87,7 +87,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Field Options</span>
           <span class="type-detail">Required Only</span>
         </div>
@@ -137,7 +137,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Edge Cases</span>
           <span class="type-detail">Two Cards</span>
         </div>
@@ -173,7 +173,7 @@
 
   <div id="content-normal" class="dropdown-selection" aria-hidden="false">
     <div class="umd-lock">
-      <h3 class="umd-sans-large type-hr">
+      <h3 class="content-heading type-hr">
         Default
       </h3>
     </div>
@@ -231,7 +231,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Field Options</span>
           <span class="type-detail">Required Only</span>
         </div>
@@ -281,7 +281,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Edge Cases</span>
           <span class="type-detail">Two Cards</span>
         </div>
@@ -317,7 +317,7 @@
 
   <div id="content-verbose" class="dropdown-selection" aria-hidden="true">
     <div class="umd-lock">
-      <h3 class="umd-sans-large type-hr">
+      <h3 class="content-heading type-hr">
         Default
       </h3>
     </div>
@@ -375,7 +375,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Field Options</span>
           <span class="type-detail">Required Only</span>
         </div>
@@ -425,7 +425,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Edge Cases</span>
           <span class="type-detail">Two Cards</span>
         </div>

--- a/packages/kitchen-sink/source/twig/components/events-date-slider.twig
+++ b/packages/kitchen-sink/source/twig/components/events-date-slider.twig
@@ -8,11 +8,11 @@
 {% block page %}
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Events Date Slider
       </h1>
 
-      <h2 class="umd-sans-large">
+      <h2 class="content-heading">
         Content Variations
       </h2>
 
@@ -23,7 +23,7 @@
   <div id="content-succinct" class="dropdown-selection" aria-hidden="true">
     <section>
       <div class="umd-lock">
-        <h3 class="umd-sans-large type-hr">
+        <h3 class="content-heading type-hr">
           Default
         </h3>
         <umd-element-events-date-slider theme="light" aria-hidden="true">
@@ -58,7 +58,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Field Options</span>
           <span class="type-detail">Without CTA</span>
         </div>
@@ -89,7 +89,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Theme</span>
           <span class="type-detail">Dark</span>
         </div>
@@ -143,7 +143,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Edge Cases</span>
           <span class="type-detail">Less than 3 dates</span>
         </div>
@@ -173,7 +173,7 @@
   <div id="content-normal" class="dropdown-selection" aria-hidden="false">
     <section>
       <div class="umd-lock">
-        <h3 class="umd-sans-large type-hr">
+        <h3 class="content-heading type-hr">
           Default
         </h3>
 
@@ -205,7 +205,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Field Options</span>
           <span class="type-detail">Without CTA</span>
         </div>
@@ -236,7 +236,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Theme</span>
           <span class="type-detail">Dark</span>
         </div>
@@ -291,7 +291,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Edge Cases</span>
           <span class="type-detail">Less than 3 dates</span>
         </div>
@@ -321,7 +321,7 @@
   <div id="content-verbose" class="dropdown-selection" aria-hidden="true">
     <section>
       <div class="umd-lock">
-        <h3 class="umd-sans-large type-hr">
+        <h3 class="content-heading type-hr">
           Default
         </h3>
 
@@ -357,7 +357,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Field Options</span>
           <span class="type-detail">Without CTA</span>
         </div>
@@ -388,7 +388,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Theme</span>
           <span class="type-detail">Dark</span>
         </div>
@@ -445,7 +445,7 @@
 
     <section>
       <div class="umd-lock">
-        <div class="umd-sans-large type-hr">
+        <div class="content-heading type-hr">
           <span class="type">Edge Cases</span>
           <span class="type-detail">Less than 3 dates</span>
         </div>

--- a/packages/kitchen-sink/source/twig/components/footer.twig
+++ b/packages/kitchen-sink/source/twig/components/footer.twig
@@ -5,7 +5,7 @@
 {% block page %}
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">Simple with default content</span>
       </p>
@@ -16,7 +16,7 @@
 
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">
           Simple with default content and styled light theme
@@ -29,7 +29,7 @@
 
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">
           Simple with information overwrites for contact, social, and utility
@@ -47,7 +47,7 @@
 
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">Mega with default content</span>
       </p>
@@ -58,7 +58,7 @@
 
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">
           Mega with default content and styled light theme
@@ -71,7 +71,7 @@
 
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">
           Mega with information overwrites for contact, social, and utility
@@ -91,7 +91,7 @@
 
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">Visual with default content</span>
       </p>
@@ -102,7 +102,7 @@
 
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">
           Visual with default content with light theme
@@ -115,7 +115,7 @@
 
   <section>
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">
           Visual with information overwrites for contact, social, link columns,

--- a/packages/kitchen-sink/source/twig/components/nav-drawer.twig
+++ b/packages/kitchen-sink/source/twig/components/nav-drawer.twig
@@ -3,7 +3,7 @@
 {% block page %}
   <section style="min-height: 20vh">
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         Default Styling
       </p>
 
@@ -79,7 +79,7 @@
 
   <section style="min-height: 20vh">
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">
           Secondary links and no additonal content
@@ -134,7 +134,7 @@
 
   <section style="min-height: 20vh">
     <div class="umd-lock">
-      <p class="umd-sans-large type-hr">
+      <p class="content-heading type-hr">
         <span class="type">Default Styling</span>
         <span class="type-detail">Context Menu</span>
       </p>

--- a/packages/kitchen-sink/source/twig/components/nav-item.twig
+++ b/packages/kitchen-sink/source/twig/components/nav-item.twig
@@ -2,12 +2,12 @@
 
 {% block page %}
   <div class="umd-lock">
-    <h1 class="umd-sans-largest">
+    <h1 class="page-heading">
       Nav Item
     </h1>
 
     <section style="min-height: 300px">
-      <h2 class="umd-sans-large type-hr">
+      <h2 class="content-heading type-hr">
         Succinct
       </h2>
 
@@ -36,7 +36,7 @@
     </section>
 
     <section style="min-height: 475px">
-      <h2 class="umd-sans-large type-hr">
+      <h2 class="content-heading type-hr">
         Default
       </h2>
 
@@ -129,7 +129,7 @@
     </section>
 
     <section style="min-height: 650px">
-      <h2 class="umd-sans-large type-hr">
+      <h2 class="content-heading type-hr">
         Verbose
       </h2>
 

--- a/packages/kitchen-sink/source/twig/components/pathway.twig
+++ b/packages/kitchen-sink/source/twig/components/pathway.twig
@@ -5,14 +5,14 @@
 {% block page %}
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Pathway
       </h1>
     </div>
 
     <section>
       <div class="umd-lock">
-        <h2 class="umd-sans-large default">
+        <h2 class="content-heading default type-hr">
           <span>Text</span>
         </h2>
       </div>
@@ -60,7 +60,7 @@
 
     <section>
       <div class="umd-lock">
-        <h2 class="umd-sans-large icon-options-hr">
+        <h2 class="content-heading type-hr">
           <span>Standard</span>
         </h2>
       </div>
@@ -95,8 +95,9 @@
 
     <section>
       <div class="umd-lock">
-        <h2 class="umd-sans-large icon-options-hr">
-          <span>Standard - image position right</span>
+        <h2 class="content-heading type-hr">
+          <span class="type">Standard</span>
+          <span class="type-detail">Image position right</span>
         </h2>
       </div>
 
@@ -130,8 +131,9 @@
 
     <section>
       <div class="umd-lock">
-        <h2 class="umd-sans-large icon-options-hr">
-          <span>Standard - image scaling off</span>
+        <h2 class="content-heading type-hr">
+          <span class="type">Standard</span>
+          <span class="type-detail">Image scaling off</span>
         </h2>
       </div>
 

--- a/packages/kitchen-sink/source/twig/feeds/news.twig
+++ b/packages/kitchen-sink/source/twig/feeds/news.twig
@@ -3,12 +3,12 @@
 {% block page %}
   <section>
     <div class="umd-lock">
-      <h1 class="umd-sans-largest">
+      <h1 class="page-heading">
         Feed News
       </h1>
 
       <section>
-        <h2 class="umd-sans-large type-hr">
+        <h2 class="content-heading type-hr">
           <span>No Results</span>
         </h2>
 
@@ -19,7 +19,7 @@
       </section>
 
       <section>
-        <h2 class="umd-sans-large type-hr">
+        <h2 class="content-heading type-hr">
           <span>Lazy Load with Do Good Category</span>
         </h2>
 

--- a/packages/kitchen-sink/source/twig/theme/components/header.twig
+++ b/packages/kitchen-sink/source/twig/theme/components/header.twig
@@ -5,7 +5,7 @@
 {% block page %}
   <section class="pb-2xl">
     <div class="umd-lock">
-      <div class="umd-sans-large type-hr">
+      <div class="content-heading type-hr">
         <span class="type">Component Header</span>
         <span class="type-detail">Provost Example</span>
       </div>
@@ -79,7 +79,7 @@
     </div>
 
     <div class="umd-lock">
-      <div class="umd-sans-large type-hr">
+      <div class="content-heading type-hr">
         <span class="type">Component Header</span>
         <span class="type-detail">Election Example</span>
       </div>
@@ -98,7 +98,7 @@
     </div>
 
     <div class="umd-lock">
-      <div class="umd-sans-large type-hr">
+      <div class="content-heading type-hr">
         <span class="type">Component Header</span>
         <span class="type-detail">Terp Example</span>
       </div>
@@ -159,7 +159,7 @@
     </div>
 
     <div class="umd-lock">
-      <div class="umd-sans-large type-hr">
+      <div class="content-heading type-hr">
         <span class="type">Component Header</span>
         <span class="type-detail">UMD Main Example</span>
       </div>
@@ -245,7 +245,7 @@
     </div>
 
     <div class="umd-lock">
-      <div class="umd-sans-large type-hr">
+      <div class="content-heading type-hr">
         <span class="type">Component Header</span>
         <span class="type-detail">Utility Example</span>
       </div>
@@ -323,7 +323,7 @@
     </div>
 
     <div class="umd-lock">
-      <div class="umd-sans-large type-hr">
+      <div class="content-heading type-hr">
         <span class="type">Component Header</span>
         <span class="type-detail">CTA Example</span>
       </div>

--- a/packages/kitchen-sink/source/twig/theme/components/section-intro.twig
+++ b/packages/kitchen-sink/source/twig/theme/components/section-intro.twig
@@ -2,7 +2,7 @@
 
 {% block page %}
   <div class="umd-lock">
-    <h1 class="umd-sans-large type-hr">
+    <h1 class="content-heading type-hr">
       Section Intro
     </h1>
 
@@ -19,7 +19,7 @@
       </div>
     </umd-component-intro>
 
-    <div class="umd-sans-large type-hr">
+    <div class="content-heading type-hr">
       <span class="type">Section Intro</span>
       <span class="type-detail">Grouping Call to Action (5)</span>
     </div>
@@ -59,7 +59,7 @@
       </div>
     </umd-component-intro>
 
-    <div class="umd-sans-large type-hr">
+    <div class="content-heading type-hr">
       <span class="type">Section Intro</span>
       <span class="type-detail">Wide</span>
     </div>


### PR DESCRIPTION
Noticed that the original Kitchen Sink CSS styles in place were interfering with other styles

- Replaced styles all that were on `umd-sans-large` with a new class of `content-heading`
- Replaced styles all that were on `umd-sans-largest` with a new class of `page-heading`

