### PR TITLE
Close DSYS-694: Add max width for section intro

### DIFF
--- a/packages/kitchen-sink/source/twig/_data/theme-components.twig
+++ b/packages/kitchen-sink/source/twig/_data/theme-components.twig
@@ -4,6 +4,10 @@
     link: 'header'
   },
   {
+    name: 'Section Intro',
+    link: 'section-intro'
+  },
+  {
     name: 'Sticky',
     link: 'sticky'
   }

--- a/packages/kitchen-sink/source/twig/theme/components/section-intro.twig
+++ b/packages/kitchen-sink/source/twig/theme/components/section-intro.twig
@@ -5,25 +5,29 @@
     <h1 class="content-heading type-hr">
       Section Intro
     </h1>
+  </div>
 
-    <umd-component-intro>
-      <div class="intro-content-wrapper">
-        <h2 class="umd-sans-largest">
-          FROM MARYLAND TODAY
-        </h2>
-        <div class="umd-layout-flex-row-auto">
-          <umd-element-call-to-action type="secondary">
-            <a href="/"><span>See all election related content</span></a>
-          </umd-element-call-to-action>
-        </div>
+  <umd-component-intro>
+    <div class="intro-content-wrapper">
+      <h2 class="umd-sans-largest">
+        FROM MARYLAND TODAY
+      </h2>
+      <div class="umd-layout-flex-row-auto">
+        <umd-element-call-to-action type="secondary">
+          <a href="/"><span>See all election related content</span></a>
+        </umd-element-call-to-action>
       </div>
-    </umd-component-intro>
+    </div>
+  </umd-component-intro>
 
+  <div class="umd-lock">
     <div class="content-heading type-hr">
       <span class="type">Section Intro</span>
       <span class="type-detail">Grouping Call to Action (5)</span>
     </div>
+  </div>
 
+  <div class="umd-lock-extra-small">
     <umd-component-intro>
       <div class="intro-content-wrapper">
         <h2 class="umd-sans-largest">
@@ -58,12 +62,16 @@
         </div>
       </div>
     </umd-component-intro>
+  </div>
 
+  <div class="umd-lock">
     <div class="content-heading type-hr">
       <span class="type">Section Intro</span>
       <span class="type-detail">Wide</span>
     </div>
+  </div>
 
+  <div class="umd-lock">
     <umd-component-intro-wide>
       <div class="intro-content-wrapper">
         <h2 class="umd-sans-largest">

--- a/packages/theme/source/components/intro.ts
+++ b/packages/theme/source/components/intro.ts
@@ -13,6 +13,7 @@ export default {
       ...SpacingContent['.umd-layout-spacing-center'],
       ...{
         margin: 'auto',
+        maxWidth: `calc(${Spacing['5xl']} * 10)`,
         paddingTop: `${Spacing['6xl']}`,
         position: 'relative',
 


### PR DESCRIPTION
This is for [DSYS-694](https://linear.app/umd-web-services/issue/DSYS-694/theme-section-intro-max-width) - adding a max width to the section intro.

To keep styles consistent, I used the same max-width as Provost section intro

[Updated staging](https://kitchen-sink-dev.umd-staging.com/theme/components/section-intro)