### PR TITLE
Close DSYS-795: Update headline styles

### DIFF
--- a/packages/kitchen-sink/source/styles/dependencies/kitchen-sink-styles.css
+++ b/packages/kitchen-sink/source/styles/dependencies/kitchen-sink-styles.css
@@ -12,32 +12,9 @@
   position: relative;
 }
 
-.type {
-  display: inline-flex;
-  align-items: center;
-  position: relative;
-}
-
-.type::after {
-  content: '';
-  position: absolute;
-  left: 100%;
-  margin-left: 0.5em;
-  height: 1em;
-  width: 1px;
-  background-color: theme(colors.gray.light);
-}
-
-.type-detail {
-  color: theme(colors.gray.medium);
-  margin-left: 1em;
-  position: relative;
-}
-
 .type-hr {
   display: flex;
   align-items: center;
-  white-space: nowwrap;
 }
 
 .type-hr::after {
@@ -46,7 +23,29 @@
   display: block;
   flex-grow: 1;
   height: 1px;
+  margin-left: 0.5em;
+}
+
+.type-hr > span:first-child {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 100%;
+    margin-left: 0.5em;
+    height: 1em;
+    width: 1px;
+    background-color: theme(colors.gray.light);
+  }
+}
+
+.type-hr > span:nth-child(2) {
+  color: theme(colors.gray.medium);
   margin-left: 1em;
+  position: relative;
 }
 
 .two-cards-hr::after {

--- a/packages/kitchen-sink/source/twig/components/alert.twig
+++ b/packages/kitchen-sink/source/twig/components/alert.twig
@@ -35,8 +35,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Notification</span>
+            <span>Type</span>
+            <span>Notification</span>
           </div>
 
           <umd-element-alert type="notification" days="0" icon="true">
@@ -52,8 +52,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Emergency</span>
+            <span>Type</span>
+            <span>Emergency</span>
           </div>
 
           <umd-element-alert type="emergency" days="0" icon="true">
@@ -69,8 +69,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
 
           <umd-element-alert type="alert" days="0" icon="true">
@@ -98,8 +98,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Notification</span>
+            <span>Type</span>
+            <span>Notification</span>
           </div>
 
           <umd-element-alert type="notification" days="0" icon="true">
@@ -115,8 +115,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Emergency</span>
+            <span>Type</span>
+            <span>Emergency</span>
           </div>
 
           <umd-element-alert type="emergency" days="0" icon="true">
@@ -132,8 +132,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
 
           <umd-element-alert type="alert" days="0" icon="true">
@@ -161,8 +161,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Notification</span>
+            <span>Type</span>
+            <span>Notification</span>
           </div>
 
           <umd-element-alert type="notification" days="0" icon="true">
@@ -178,8 +178,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Emergency</span>
+            <span>Type</span>
+            <span>Emergency</span>
           </div>
 
           <umd-element-alert type="emergency" days="0" icon="true">
@@ -195,8 +195,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
 
           <umd-element-alert type="alert" days="0" icon="true">

--- a/packages/kitchen-sink/source/twig/components/article.twig
+++ b/packages/kitchen-sink/source/twig/components/article.twig
@@ -40,8 +40,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Outlined</span>
+            <span>Type</span>
+            <span>Outlined</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -57,8 +57,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Aligned</span>
+            <span>Layout</span>
+            <span>Aligned</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -74,8 +74,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -94,8 +94,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Minimal</span>
+            <span>Field Options</span>
+            <span>Minimal</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -114,8 +114,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -131,8 +131,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
           <div class="umd-grid-three mb-md" style="margin-top: 24px">
             {{
@@ -167,8 +167,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -204,8 +204,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
           <div class="umd-grid mb-md" style="margin-top: 24px">
             {{
@@ -247,8 +247,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Outlined</span>
+            <span>Type</span>
+            <span>Outlined</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -264,8 +264,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Aligned</span>
+            <span>Layout</span>
+            <span>Aligned</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -281,8 +281,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -300,8 +300,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Minimal</span>
+            <span>Field Options</span>
+            <span>Minimal</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -320,8 +320,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -336,8 +336,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
           <div class="umd-grid-three mb-md" style="margin-top: 24px">
             {{
@@ -372,8 +372,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -409,8 +409,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
           <div class="umd-grid mb-md" style="margin-top: 24px">
             {{
@@ -452,8 +452,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Outlined</span>
+            <span>Type</span>
+            <span>Outlined</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -469,8 +469,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Aligned</span>
+            <span>Layout</span>
+            <span>Aligned</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -486,8 +486,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -505,8 +505,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Minimal</span>
+            <span>Field Options</span>
+            <span>Minimal</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -525,8 +525,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -541,8 +541,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
           <div class="umd-grid-three mb-md" style="margin-top: 24px">
             {{
@@ -577,8 +577,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -614,8 +614,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
           <div class="umd-grid mb-md" style="margin-top: 24px">
             {{
@@ -643,8 +643,8 @@
       <section>
         <div class="umd-lock-smallest">
           <h3 class="content-heading type-hr">
-            <span class="type">Article</span>
-            <span class="type-detail">List Style</span>
+            <span>Article</span>
+            <span>List Style</span>
           </h3>
 
           <umd-element-article display="list">
@@ -757,8 +757,8 @@
       <section style="background-color: black; padding; 50px 0;  margin-bottom: 40px;">
         <div class="umd-lock-smallest">
           <h3 class="content-heading type-hr">
-            <span class="type" style="color: white">Article</span>
-            <span class="type-detail">List Style - Theme Dark</span>
+            <span style="color: white">Article</span>
+            <span>List Style - Theme Dark</span>
           </h3>
 
           <umd-element-article display="list" theme="dark">

--- a/packages/kitchen-sink/source/twig/components/call-to-action-button.twig
+++ b/packages/kitchen-sink/source/twig/components/call-to-action-button.twig
@@ -37,8 +37,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Primary Styling</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -57,8 +57,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Primary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         {{
@@ -92,8 +92,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Secondary Styling</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -111,8 +111,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Secondary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="cta-layout">
@@ -148,8 +148,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Outline Styling</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -167,8 +167,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Outline Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="cta-layout">
@@ -206,8 +206,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Primary Styling</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -226,8 +226,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Primary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         {{
@@ -261,8 +261,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Secondary Styling</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -280,8 +280,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Secondary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="cta-layout">
@@ -317,8 +317,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Outline Styling</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -336,8 +336,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Outline Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="cta-layout">
@@ -374,8 +374,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Primary Styling</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -394,8 +394,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Primary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         {{
@@ -429,8 +429,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Secondary Styling</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -448,8 +448,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Secondary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="cta-layout">
@@ -486,7 +486,7 @@
       <div class="umd-lock">
         <p class="content-heading type-hr">
           <span class="theme">Outline Styling</span>
-          <span class="type-detail">Icon Example</span>
+          <span>Icon Example</span>
         </p>
 
         <div class="cta-layout">
@@ -504,8 +504,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Outline Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="cta-layout">

--- a/packages/kitchen-sink/source/twig/components/call-to-action.twig
+++ b/packages/kitchen-sink/source/twig/components/call-to-action.twig
@@ -37,8 +37,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Icon options</span>
+          <span>Primary Styling</span>
+          <span>Icon options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -73,8 +73,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Primary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -126,8 +126,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Icon options</span>
+          <span>Secondary Styling</span>
+          <span>Icon options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -161,8 +161,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Secondary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -212,8 +212,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Icon Options</span>
+          <span>Outline Styling</span>
+          <span>Icon Options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -245,8 +245,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Outline Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -308,8 +308,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Combo</span>
-          <span class="type-detail">Primary with Plain Text Slot</span>
+          <span>Combo</span>
+          <span>Primary with Plain Text Slot</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -328,8 +328,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Combo</span>
-          <span class="type-detail">Secondary with Plain Text Slot</span>
+          <span>Combo</span>
+          <span>Secondary with Plain Text Slot</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -347,8 +347,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Primary Styling</span>
+          <span>Theme Dark</span>
+          <span>Primary Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -366,8 +366,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Secondary Styling</span>
+          <span>Theme Dark</span>
+          <span>Secondary Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -385,8 +385,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Outline Styling</span>
+          <span>Theme Dark</span>
+          <span>Outline Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -420,8 +420,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Icon options</span>
+          <span>Primary Styling</span>
+          <span>Icon options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -456,8 +456,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Primary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -509,8 +509,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Icon options</span>
+          <span>Secondary Styling</span>
+          <span>Icon options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -544,8 +544,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Secondary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -595,8 +595,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Icon Options</span>
+          <span>Outline Styling</span>
+          <span>Icon Options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -628,8 +628,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Outline Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -691,8 +691,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Combo</span>
-          <span class="type-detail">Primary with Plain Text Slot</span>
+          <span>Combo</span>
+          <span>Primary with Plain Text Slot</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -711,8 +711,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Combo</span>
-          <span class="type-detail">Secondary with Plain Text Slot</span>
+          <span>Combo</span>
+          <span>Secondary with Plain Text Slot</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -730,8 +730,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Primary Styling</span>
+          <span>Theme Dark</span>
+          <span>Primary Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -749,8 +749,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Secondary Styling</span>
+          <span>Theme Dark</span>
+          <span>Secondary Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -768,8 +768,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Outline Styling</span>
+          <span>Theme Dark</span>
+          <span>Outline Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -805,8 +805,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Icon options</span>
+          <span>Primary Styling</span>
+          <span>Icon options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -841,8 +841,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Primary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Primary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -894,8 +894,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Icon options</span>
+          <span>Secondary Styling</span>
+          <span>Icon options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -929,8 +929,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Secondary Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Secondary Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -980,8 +980,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Icon Options</span>
+          <span>Outline Styling</span>
+          <span>Icon Options</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -1013,8 +1013,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Outline Styling</span>
-          <span class="type-detail">Sized Large</span>
+          <span>Outline Styling</span>
+          <span>Sized Large</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -1076,8 +1076,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Combo</span>
-          <span class="type-detail">Primary with Plain Text Slot</span>
+          <span>Combo</span>
+          <span>Primary with Plain Text Slot</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -1096,8 +1096,8 @@
     <section>
       <div class="umd-lock">
         <p class="content-heading type-hr">
-          <span class="type">Combo</span>
-          <span class="type-detail">Secondary with Plain Text Slot</span>
+          <span>Combo</span>
+          <span>Secondary with Plain Text Slot</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -1115,8 +1115,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Primary Styling</span>
+          <span>Theme Dark</span>
+          <span>Primary Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -1134,8 +1134,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Secondary Styling</span>
+          <span>Theme Dark</span>
+          <span>Secondary Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -1153,8 +1153,8 @@
     <section style="background-color: black; padding: 40px 0;">
       <div class="umd-lock">
         <p class="content-heading type-hr" style="color: white">
-          <span class="type">Theme Dark</span>
-          <span class="type-detail">Outline Styling</span>
+          <span>Theme Dark</span>
+          <span>Outline Styling</span>
         </p>
 
         <div class="umd-layout-flex-row-auto">
@@ -1173,8 +1173,8 @@
   <section style="margin-bottom: 40px">
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Edge Case</span>
-        <span class="type-detail">SVG Styling in Card</span>
+        <span>Edge Case</span>
+        <span>SVG Styling in Card</span>
       </p>
 
       <div class="umd-grid-three">

--- a/packages/kitchen-sink/source/twig/components/card-overlay.twig
+++ b/packages/kitchen-sink/source/twig/components/card-overlay.twig
@@ -41,8 +41,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -59,8 +59,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Optional Date</span>
+            <span>Field Options</span>
+            <span>Optional Date</span>
           </div>
 
           <div class="umd-grid-three my-md">
@@ -75,8 +75,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">CTA Icons</span>
+            <span>Field Options</span>
+            <span>CTA Icons</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -106,8 +106,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -122,8 +122,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Light</span>
+            <span>Theme</span>
+            <span>Light</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -137,10 +137,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">
-              Grid Configuration Animation Grouping (3)
-            </span>
+            <span>Layout</span>
+            <span>Grid Configuration Animation Grouping (3)</span>
           </div>
 
           <div class="umd-grid-three-float-overlay-card my-md">
@@ -166,10 +164,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">
-              Grid Configuration Animation Grouping (4)
-            </span>
+            <span>Layout</span>
+            <span>Grid Configuration Animation Grouping (4)</span>
           </div>
 
           <div class="umd-grid-four-float-overlay-card my-md">
@@ -201,8 +197,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
 
           <div class="umd-grid-three my-md">
@@ -228,8 +224,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
 
           <div class="umd-grid-four my-md">
@@ -261,8 +257,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
 
           <div class="umd-grid my-md">
@@ -298,8 +294,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -316,8 +312,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Optional Date</span>
+            <span>Field Options</span>
+            <span>Optional Date</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -331,8 +327,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">CTA Icons</span>
+            <span>Field Options</span>
+            <span>CTA Icons</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -362,8 +358,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -378,8 +374,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Light</span>
+            <span>Theme</span>
+            <span>Light</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -394,10 +390,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">
-              Grid Configuration Animation Grouping (3)
-            </span>
+            <span>Layout</span>
+            <span>Grid Configuration Animation Grouping (3)</span>
           </div>
 
           <div class="umd-grid-three-float-overlay-card my-md">
@@ -423,10 +417,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">
-              Grid Configuration Animation Grouping (4)
-            </span>
+            <span>Layout</span>
+            <span>Grid Configuration Animation Grouping (4)</span>
           </div>
 
           <div class="umd-grid-four-float-overlay-card my-md">
@@ -458,8 +450,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
 
           <div class="umd-grid-three my-md">
@@ -485,8 +477,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
 
           <div class="umd-grid-four my-md">
@@ -518,8 +510,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
 
           <div class="umd-grid my-md">
@@ -555,8 +547,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -573,8 +565,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Optional Date</span>
+            <span>Field Options</span>
+            <span>Optional Date</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -588,8 +580,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">CTA Icons</span>
+            <span>Field Options</span>
+            <span>CTA Icons</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -619,8 +611,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -635,8 +627,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Light</span>
+            <span>Theme</span>
+            <span>Light</span>
           </div>
           <div class="umd-grid-three my-md">
             {{
@@ -651,10 +643,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">
-              Grid Configuration Animation Grouping (3)
-            </span>
+            <span>Layout</span>
+            <span>Grid Configuration Animation Grouping (3)</span>
           </div>
 
           <div class="umd-grid-three-float-overlay-card my-md">
@@ -680,10 +670,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">
-              Grid Configuration Animation Grouping (4)
-            </span>
+            <span>Layout</span>
+            <span>Grid Configuration Animation Grouping (4)</span>
           </div>
 
           <div class="umd-grid-four-float-overlay-card my-md">
@@ -715,8 +703,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
 
           <div class="umd-grid-three my-md">
@@ -742,8 +730,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
 
           <div class="umd-grid-four my-md">
@@ -775,8 +763,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
 
           <div class="umd-grid my-md">
@@ -799,8 +787,8 @@
     <section style="padding-bottom: 10vh">
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Edge Cases</span>
-          <span class="type-detail">Gif</span>
+          <span>Edge Cases</span>
+          <span>Gif</span>
         </div>
 
         <div class="umd-grid-three my-md">

--- a/packages/kitchen-sink/source/twig/components/card.twig
+++ b/packages/kitchen-sink/source/twig/components/card.twig
@@ -39,8 +39,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Outlined</span>
+            <span>Type</span>
+            <span>Outlined</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -55,8 +55,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Aligned</span>
+            <span>Layout</span>
+            <span>Aligned</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -71,8 +71,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -90,8 +90,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Minimal</span>
+            <span>Field Options</span>
+            <span>Minimal</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -109,8 +109,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -126,8 +126,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
           <div class="umd-grid-three mb-md" style="margin-top: 24px">
             {{
@@ -159,8 +159,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -196,8 +196,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
           <div class="umd-grid mb-md" style="margin-top: 24px">
             {{
@@ -236,8 +236,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Outlined</span>
+            <span>Type</span>
+            <span>Outlined</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -252,8 +252,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Aligned</span>
+            <span>Layout</span>
+            <span>Aligned</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -268,8 +268,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -286,8 +286,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Minimal</span>
+            <span>Field Options</span>
+            <span>Minimal</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -305,8 +305,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -321,8 +321,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
           <div class="umd-grid-three mb-md" style="margin-top: 24px">
             {{
@@ -354,8 +354,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -391,8 +391,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
           <div class="umd-grid mb-md" style="margin-top: 24px">
             {{
@@ -431,8 +431,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Type</span>
-            <span class="type-detail">Outlined</span>
+            <span>Type</span>
+            <span>Outlined</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -447,8 +447,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Aligned</span>
+            <span>Layout</span>
+            <span>Aligned</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -463,8 +463,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Required Only</span>
+            <span>Field Options</span>
+            <span>Required Only</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -481,8 +481,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Field Options</span>
-            <span class="type-detail">Minimal</span>
+            <span>Field Options</span>
+            <span>Minimal</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -500,8 +500,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Theme</span>
-            <span class="type-detail">Dark</span>
+            <span>Theme</span>
+            <span>Dark</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -516,8 +516,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (3)</span>
+            <span>Layout</span>
+            <span>Grouping (3)</span>
           </div>
           <div class="umd-grid-three mb-md" style="margin-top: 24px">
             {{
@@ -549,8 +549,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (4)</span>
+            <span>Layout</span>
+            <span>Grouping (4)</span>
           </div>
           <div class="umd-grid-four mb-md" style="margin-top: 24px">
             {{
@@ -586,8 +586,8 @@
 
         <section>
           <div class="content-heading type-hr">
-            <span class="type">Layout</span>
-            <span class="type-detail">Grouping (2)</span>
+            <span>Layout</span>
+            <span>Grouping (2)</span>
           </div>
           <div class="umd-grid mb-md" style="margin-top: 24px">
             {{
@@ -620,8 +620,8 @@
 
       <section>
         <div class="content-heading type-hr">
-          <span class="type">Layout</span>
-          <span class="type-detail">Grouping (2)</span>
+          <span>Layout</span>
+          <span>Grouping (2)</span>
         </div>
         <div class="umd-grid-four">
           <umd-element-card>
@@ -843,8 +843,8 @@
       <section>
         <div class="umd-lock-smallest">
           <h3 class="content-heading type-hr">
-            <span class="type">Card</span>
-            <span class="type-detail">List Style</span>
+            <span>Card</span>
+            <span>List Style</span>
           </h3>
 
           <umd-element-card display="list">
@@ -949,8 +949,8 @@
       <section style="background-color: black; padding; 50px 0;  margin-bottom: 40px;">
         <div class="umd-lock-smallest">
           <h3 class="content-heading type-hr">
-            <span class="type" style="color: white">Card</span>
-            <span class="type-detail">List Style - Theme Dark</span>
+            <span style="color: white">Card</span>
+            <span>List Style - Theme Dark</span>
           </h3>
 
           <umd-element-card display="list" theme="dark">

--- a/packages/kitchen-sink/source/twig/components/carousel-cards.twig
+++ b/packages/kitchen-sink/source/twig/components/carousel-cards.twig
@@ -88,8 +88,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Field Options</span>
-          <span class="type-detail">Required Only</span>
+          <span>Field Options</span>
+          <span>Required Only</span>
         </div>
       </div>
       <umd-element-carousel-cards resize>
@@ -138,8 +138,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Edge Cases</span>
-          <span class="type-detail">Two Cards</span>
+          <span>Edge Cases</span>
+          <span>Two Cards</span>
         </div>
       </div>
 
@@ -232,8 +232,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Field Options</span>
-          <span class="type-detail">Required Only</span>
+          <span>Field Options</span>
+          <span>Required Only</span>
         </div>
       </div>
       <umd-element-carousel-cards resize>
@@ -282,8 +282,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Edge Cases</span>
-          <span class="type-detail">Two Cards</span>
+          <span>Edge Cases</span>
+          <span>Two Cards</span>
         </div>
       </div>
 
@@ -376,8 +376,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Field Options</span>
-          <span class="type-detail">Required Only</span>
+          <span>Field Options</span>
+          <span>Required Only</span>
         </div>
       </div>
       <umd-element-carousel-cards resize>
@@ -426,8 +426,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Edge Cases</span>
-          <span class="type-detail">Two Cards</span>
+          <span>Edge Cases</span>
+          <span>Two Cards</span>
         </div>
       </div>
 

--- a/packages/kitchen-sink/source/twig/components/events-date-slider.twig
+++ b/packages/kitchen-sink/source/twig/components/events-date-slider.twig
@@ -59,8 +59,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Field Options</span>
-          <span class="type-detail">Without CTA</span>
+          <span>Field Options</span>
+          <span>Without CTA</span>
         </div>
 
         <umd-element-events-date-slider theme="light" resize>
@@ -90,8 +90,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Theme</span>
-          <span class="type-detail">Dark</span>
+          <span>Theme</span>
+          <span>Dark</span>
         </div>
 
         <umd-element-events-date-slider theme="dark" resize>
@@ -144,8 +144,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Edge Cases</span>
-          <span class="type-detail">Less than 3 dates</span>
+          <span>Edge Cases</span>
+          <span>Less than 3 dates</span>
         </div>
 
         <umd-element-events-date-slider theme="light" resize>
@@ -206,8 +206,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Field Options</span>
-          <span class="type-detail">Without CTA</span>
+          <span>Field Options</span>
+          <span>Without CTA</span>
         </div>
 
         <umd-element-events-date-slider theme="light" resize>
@@ -237,8 +237,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Theme</span>
-          <span class="type-detail">Dark</span>
+          <span>Theme</span>
+          <span>Dark</span>
         </div>
 
         <umd-element-events-date-slider theme="dark" resize>
@@ -292,8 +292,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Edge Cases</span>
-          <span class="type-detail">Less than 3 dates</span>
+          <span>Edge Cases</span>
+          <span>Less than 3 dates</span>
         </div>
 
         <umd-element-events-date-slider theme="light" resize>
@@ -358,8 +358,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Field Options</span>
-          <span class="type-detail">Without CTA</span>
+          <span>Field Options</span>
+          <span>Without CTA</span>
         </div>
 
         <umd-element-events-date-slider theme="light" resize>
@@ -389,8 +389,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Theme</span>
-          <span class="type-detail">Dark</span>
+          <span>Theme</span>
+          <span>Dark</span>
         </div>
 
         <umd-element-events-date-slider theme="dark" resize>
@@ -446,8 +446,8 @@
     <section>
       <div class="umd-lock">
         <div class="content-heading type-hr">
-          <span class="type">Edge Cases</span>
-          <span class="type-detail">Less than 3 dates</span>
+          <span>Edge Cases</span>
+          <span>Less than 3 dates</span>
         </div>
 
         <umd-element-events-date-slider theme="light">

--- a/packages/kitchen-sink/source/twig/components/footer.twig
+++ b/packages/kitchen-sink/source/twig/components/footer.twig
@@ -6,8 +6,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">Simple with default content</span>
+        <span>Default Styling</span>
+        <span>Simple with default content</span>
       </p>
     </div>
 
@@ -17,10 +17,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">
-          Simple with default content and styled light theme
-        </span>
+        <span>Default Styling</span>
+        <span>Simple with default content and styled light theme</span>
       </p>
     </div>
 
@@ -30,8 +28,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">
+        <span>Default Styling</span>
+        <span>
           Simple with information overwrites for contact, social, and utility
           links
         </span>
@@ -48,8 +46,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">Mega with default content</span>
+        <span>Default Styling</span>
+        <span>Mega with default content</span>
       </p>
     </div>
 
@@ -59,10 +57,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">
-          Mega with default content and styled light theme
-        </span>
+        <span>Default Styling</span>
+        <span>Mega with default content and styled light theme</span>
       </p>
     </div>
 
@@ -72,8 +68,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">
+        <span>Default Styling</span>
+        <span>
           Mega with information overwrites for contact, social, and utility
           links
         </span>
@@ -92,8 +88,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">Visual with default content</span>
+        <span>Default Styling</span>
+        <span>Visual with default content</span>
       </p>
     </div>
 
@@ -103,10 +99,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">
-          Visual with default content with light theme
-        </span>
+        <span>Default Styling</span>
+        <span>Visual with default content with light theme</span>
       </p>
     </div>
 
@@ -116,8 +110,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">
+        <span>Default Styling</span>
+        <span>
           Visual with information overwrites for contact, social, link columns,
           cta, image and utility links
         </span>
@@ -140,8 +134,8 @@
   <section>
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">Visual with simiple type</span>
+        <span>Default Styling</span>
+        <span>Visual with simiple type</span>
       </p>
     </div>
 

--- a/packages/kitchen-sink/source/twig/components/nav-drawer.twig
+++ b/packages/kitchen-sink/source/twig/components/nav-drawer.twig
@@ -80,10 +80,8 @@
   <section style="min-height: 20vh">
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">
-          Secondary links and no additonal content
-        </span>
+        <span>Default Styling</span>
+        <span>Secondary links and no additonal content</span>
       </p>
 
       <umd-element-nav-drawer>
@@ -135,8 +133,8 @@
   <section style="min-height: 20vh">
     <div class="umd-lock">
       <p class="content-heading type-hr">
-        <span class="type">Default Styling</span>
-        <span class="type-detail">Context Menu</span>
+        <span>Default Styling</span>
+        <span>Context Menu</span>
       </p>
 
       <umd-element-nav-drawer>

--- a/packages/kitchen-sink/source/twig/components/pathway.twig
+++ b/packages/kitchen-sink/source/twig/components/pathway.twig
@@ -14,7 +14,7 @@
       <div class="umd-lock">
         <h2 class="content-heading default type-hr">
           <span>Highlight</span>
-          <span class="type-detail">Light Theme</span>
+          <span>Light Theme</span>
         </h2>
       </div>
 
@@ -67,7 +67,7 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span>Standard</span>
+          Standard
         </h2>
       </div>
 
@@ -106,8 +106,8 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span class="type">Standard</span>
-          <span class="type-detail">Image position right</span>
+          <span>Standard</span>
+          <span>Image position right</span>
         </h2>
       </div>
 
@@ -146,8 +146,8 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span class="type">Standard</span>
-          <span class="type-detail">Image scaling off</span>
+          <span>Standard</span>
+          <span>Image scaling off</span>
         </h2>
       </div>
 
@@ -186,7 +186,7 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span class="type">Hero</span>
+          Hero
         </h2>
       </div>
 
@@ -225,8 +225,8 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span class="type">Hero</span>
-          <span class="type-detail">Image Right</span>
+          <span>Hero</span>
+          <span>Image Right</span>
         </h2>
       </div>
 
@@ -265,8 +265,8 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span class="type">Hero</span>
-          <span class="type-detail">Theme Dark</span>
+          <span>Hero</span>
+          <span>Theme Dark</span>
         </h2>
       </div>
 
@@ -305,8 +305,8 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span class="type">Hero</span>
-          <span class="type-detail">Theme Light</span>
+          <span>Hero</span>
+          <span>Theme Light</span>
         </h2>
       </div>
 
@@ -345,8 +345,8 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span class="type">Hero</span>
-          <span class="type-detail">Theme Maryland</span>
+          <span>Hero</span>
+          <span>Theme Maryland</span>
         </h2>
       </div>
 
@@ -400,8 +400,8 @@
     <section>
       <div class="umd-lock">
         <h2 class="content-heading type-hr">
-          <span class="type">Hero</span>
-          <span class="type-detail">Theme White</span>
+          <span>Hero</span>
+          <span>Theme White</span>
         </h2>
       </div>
 

--- a/packages/kitchen-sink/source/twig/components/person.twig
+++ b/packages/kitchen-sink/source/twig/components/person.twig
@@ -14,8 +14,8 @@
     <section>
       <div class="umd-lock">
         <h3 class="content-heading type-hr">
-          <span class="type">Default</span>
-          <span class="type-detail">Display Type Block</span>
+          <span>Default</span>
+          <span>Display Type Block</span>
         </h3>
 
         <div class="umd-grid-three mb-md" style="margin-top: 24px">
@@ -126,8 +126,8 @@
     <section style="background-color: black; padding: 50px 0; margin-bottom: 40px;">
       <div class="umd-lock">
         <h3 class="content-heading type-hr">
-          <span class="type" style="color: white;">Default</span>
-          <span class="type-detail">Theme Dark</span>
+          <span style="color: white;">Default</span>
+          <span>Theme Dark</span>
         </h3>
 
         <div class="umd-grid-three mb-md" style="margin-top: 24px">
@@ -238,8 +238,8 @@
     <section>
       <div class="umd-lock-smallest">
         <h3 class="content-heading type-hr">
-          <span class="type">Default</span>
-          <span class="type-detail">Display Type List</span>
+          <span>Default</span>
+          <span>Display Type List</span>
         </h3>
 
         <umd-element-person display="list">
@@ -345,8 +345,8 @@
     <section style="background-color: black; padding: 50px 0; margin-bottom: 40px;">
       <div class="umd-lock-smallest">
         <h3 class="content-heading type-hr">
-          <span class="type" style="color: white;">Default</span>
-          <span class="type-detail">Theme Dark & Display Type List</span>
+          <span style="color: white;">Default</span>
+          <span>Theme Dark & Display Type List</span>
         </h3>
 
         <umd-element-person theme="dark" display="list">

--- a/packages/kitchen-sink/source/twig/components/stat.twig
+++ b/packages/kitchen-sink/source/twig/components/stat.twig
@@ -32,8 +32,8 @@
     <section style="background-color: black; padding: 50px 0;">
       <div class="umd-lock-smallest">
         <h3 class="content-heading type-hr">
-          <span class="type" style="color: white">Default</span>
-          <span class="type-detail">Theme Dark</span>
+          <span style="color: white">Default</span>
+          <span>Theme Dark</span>
         </h3>
 
         <umd-element-stat theme="dark">
@@ -54,7 +54,7 @@
     <section>
       <div class="umd-lock-smallest">
         <h3 class="content-heading type-hr">
-          <span class="type">Size Large</span>
+          Size Large
         </h3>
 
         <umd-element-stat size="large">
@@ -75,8 +75,8 @@
     <section style="background-color: black; padding: 50px 0;">
       <div class="umd-lock-smallest">
         <h3 class="content-heading type-hr">
-          <span class="type" style="color: white">Size Large</span>
-          <span class="type-detail">Theme Dark</span>
+          <span style="color: white">Size Large</span>
+          <span>Theme Dark</span>
         </h3>
 
         <umd-element-stat theme="dark" size="large">
@@ -97,8 +97,8 @@
     <section>
       <div class="umd-lock-smallest">
         <h3 class="content-heading type-hr">
-          <span class="type">Size Large</span>
-          <span class="type-detail">With Line</span>
+          <span>Size Large</span>
+          <span>With Line</span>
         </h3>
 
         <umd-element-stat size="large" has-line>
@@ -119,8 +119,8 @@
     <section style="background-color: black; padding: 50px 0;">
       <div class="umd-lock-smallest">
         <h3 class="content-heading type-hr">
-          <span class="type" style="color: white">Size Large With Line</span>
-          <span class="type-detail">Theme Dark</span>
+          <span style="color: white">Size Large With Line</span>
+          <span>Theme Dark</span>
         </h3>
 
         <umd-element-stat theme="dark" size="large" has-line>
@@ -141,8 +141,8 @@
     <section style="padding-bottom: 10vh">
       <div class="umd-lock-smallest">
         <h3 class="content-heading type-hr">
-          <span class="type">Default</span>
-          <span class="type-detail">Long Text</span>
+          <span>Default</span>
+          <span>Long Text</span>
         </h3>
 
         <umd-element-stat>

--- a/packages/kitchen-sink/source/twig/feeds/events-grid.twig
+++ b/packages/kitchen-sink/source/twig/feeds/events-grid.twig
@@ -9,7 +9,7 @@
 
       <section>
         <h2 class="content-heading type-hr">
-          <span>No Results</span>
+          No Results
         </h2>
 
         <umd-feed-events token="4zVU8phSIImj9Pb_XhvCLEj-OU5N6Rxw"
@@ -20,8 +20,8 @@
 
       <section style="padding-bottom: 40px">
         <h2 class="content-heading type-hr">
-          <span class="type">Grid Two</span>
-          <span class="type-detail">Lazy Load with Stamp Events</span>
+          <span>Grid Two</span>
+          <span>Lazy Load with Stamp Events</span>
         </h2>
 
         <umd-feed-events token="4zVU8phSIImj9Pb_XhvCLEj-OU5N6Rxw"
@@ -33,8 +33,8 @@
 
       <section style="padding-bottom: 40px">
         <h2 class="content-heading type-hr">
-          <span class="type">Grid Three</span>
-          <span class="type-detail">Lazy Load with Stamp Events</span>
+          <span>Grid Three</span>
+          <span>Lazy Load with Stamp Events</span>
         </h2>
 
         <umd-feed-events token="4zVU8phSIImj9Pb_XhvCLEj-OU5N6Rxw"
@@ -45,8 +45,8 @@
 
       <section style="padding-bottom: 10vh">
         <h2 class="content-heading type-hr">
-          <span class="type">Grid Four</span>
-          <span class="type-detail">Lazy Load with Stamp Events</span>
+          <span>Grid Four</span>
+          <span>Lazy Load with Stamp Events</span>
         </h2>
 
         <umd-feed-events token="4zVU8phSIImj9Pb_XhvCLEj-OU5N6Rxw"

--- a/packages/kitchen-sink/source/twig/feeds/events-list.twig
+++ b/packages/kitchen-sink/source/twig/feeds/events-list.twig
@@ -9,7 +9,7 @@
 
       <section>
         <h2 class="content-heading type-hr">
-          <span>No Results</span>
+          No Results
         </h2>
 
         <umd-feed-events-list token="4zVU8phSIImj9Pb_XhvCLEj-OU5N6Rxw"
@@ -20,8 +20,8 @@
 
       <section>
         <h2 class="content-heading type-hr">
-          <span class="type">All Events</span>
-          <span class="type-detail">Limit 5</span>
+          <span>All Events</span>
+          <span>Limit 5</span>
         </h2>
 
         <div style="max-width: 800px; margin: 0 auto;">
@@ -31,8 +31,8 @@
 
       <section>
         <h2 class="content-heading type-hr">
-          <span class="type">Lazy Load with Stamp Events</span>
-          <span class="type-detail">Limit 5</span>
+          <span>Lazy Load with Stamp Events</span>
+          <span>Limit 5</span>
         </h2>
 
         <div style="max-width: 800px; margin: 0 auto;">
@@ -44,8 +44,8 @@
 
       <section style="padding-bottom: 20vh">
         <h2 class="content-heading type-hr">
-          <span class="type">Lazy Load with Stamp Events</span>
-          <span class="type-detail">Limit 10</span>
+          <span>Lazy Load with Stamp Events</span>
+          <span>Limit 10</span>
         </h2>
 
         <div style="max-width: 800px; margin: 0 auto;">

--- a/packages/kitchen-sink/source/twig/feeds/news-grid.twig
+++ b/packages/kitchen-sink/source/twig/feeds/news-grid.twig
@@ -9,7 +9,7 @@
 
       <section>
         <h2 class="content-heading type-hr">
-          <span>No Results</span>
+          No Results
         </h2>
 
         <umd-feed-news token="a3hwwnbL1aQtDZHr0-KhBC_XuyOZoG9l"
@@ -20,8 +20,8 @@
 
       <section style="padding-bottom: 40px">
         <h2 class="content-heading type-hr">
-          <span class="type">Grid Two</span>
-          <span class="type-detail">Lazy Load with Do Good Category</span>
+          <span>Grid Two</span>
+          <span>Lazy Load with Do Good Category</span>
         </h2>
 
         <umd-feed-news token="a3hwwnbL1aQtDZHr0-KhBC_XuyOZoG9l"
@@ -33,8 +33,8 @@
 
       <section style="padding-bottom: 40px">
         <h2 class="content-heading type-hr">
-          <span class="type">Grid Three</span>
-          <span class="type-detail">Lazy Load with Do Good Category</span>
+          <span>Grid Three</span>
+          <span>Lazy Load with Do Good Category</span>
         </h2>
 
         <umd-feed-news token="a3hwwnbL1aQtDZHr0-KhBC_XuyOZoG9l"
@@ -45,8 +45,8 @@
 
       <section style="padding-bottom: 10vh">
         <h2 class="content-heading type-hr">
-          <span class="type">Grid Four</span>
-          <span class="type-detail">Lazy Load with Do Good Category</span>
+          <span>Grid Four</span>
+          <span>Lazy Load with Do Good Category</span>
         </h2>
 
         <umd-feed-news token="a3hwwnbL1aQtDZHr0-KhBC_XuyOZoG9l"

--- a/packages/kitchen-sink/source/twig/feeds/news-list.twig
+++ b/packages/kitchen-sink/source/twig/feeds/news-list.twig
@@ -9,7 +9,7 @@
 
       <section>
         <h2 class="content-heading type-hr">
-          <span>No Results</span>
+          No Results
         </h2>
 
         <umd-feed-news-list token="a3hwwnbL1aQtDZHr0-KhBC_XuyOZoG9l"
@@ -20,8 +20,8 @@
 
       <section>
         <h2 class="content-heading type-hr">
-          <span class="type">All Events</span>
-          <span class="type-detail">Limit 5</span>
+          <span>All Events</span>
+          <span>Limit 5</span>
         </h2>
 
         <div style="max-width: 800px; margin: 0 auto;">
@@ -31,8 +31,8 @@
 
       <section>
         <h2 class="content-heading type-hr">
-          <span class="type">Lazy Load with Do Good Category</span>
-          <span class="type-detail">Limit 5</span>
+          <span>Lazy Load with Do Good Category</span>
+          <span>Limit 5</span>
         </h2>
 
         <div style="max-width: 800px; margin: 0 auto;">
@@ -44,8 +44,8 @@
 
       <section style="padding-bottom: 20vh">
         <h2 class="content-heading type-hr">
-          <span class="type">Lazy Load with Do Good Category</span>
-          <span class="type-detail">Limit 10</span>
+          <span>Lazy Load with Do Good Category</span>
+          <span>Limit 10</span>
         </h2>
 
         <div style="max-width: 800px; margin: 0 auto;">

--- a/packages/kitchen-sink/source/twig/theme/components/header.twig
+++ b/packages/kitchen-sink/source/twig/theme/components/header.twig
@@ -6,8 +6,8 @@
   <section class="pb-2xl">
     <div class="umd-lock">
       <div class="content-heading type-hr">
-        <span class="type">Component Header</span>
-        <span class="type-detail">Provost Example</span>
+        <span>Component Header</span>
+        <span>Provost Example</span>
       </div>
 
       <umd-component-header role="navigation">
@@ -80,8 +80,8 @@
 
     <div class="umd-lock">
       <div class="content-heading type-hr">
-        <span class="type">Component Header</span>
-        <span class="type-detail">Election Example</span>
+        <span>Component Header</span>
+        <span>Election Example</span>
       </div>
 
       <umd-component-header role="navigation">
@@ -99,8 +99,8 @@
 
     <div class="umd-lock">
       <div class="content-heading type-hr">
-        <span class="type">Component Header</span>
-        <span class="type-detail">Terp Example</span>
+        <span>Component Header</span>
+        <span>Terp Example</span>
       </div>
 
       <umd-component-header role="navigation">
@@ -160,8 +160,8 @@
 
     <div class="umd-lock">
       <div class="content-heading type-hr">
-        <span class="type">Component Header</span>
-        <span class="type-detail">UMD Main Example</span>
+        <span>Component Header</span>
+        <span>UMD Main Example</span>
       </div>
 
       <umd-component-header role="navigation">
@@ -246,8 +246,8 @@
 
     <div class="umd-lock">
       <div class="content-heading type-hr">
-        <span class="type">Component Header</span>
-        <span class="type-detail">Utility Example</span>
+        <span>Component Header</span>
+        <span>Utility Example</span>
       </div>
 
       <umd-component-header role="navigation">
@@ -324,8 +324,8 @@
 
     <div class="umd-lock">
       <div class="content-heading type-hr">
-        <span class="type">Component Header</span>
-        <span class="type-detail">CTA Example</span>
+        <span>Component Header</span>
+        <span>CTA Example</span>
       </div>
     </div>
 

--- a/packages/kitchen-sink/source/twig/theme/components/section-intro.twig
+++ b/packages/kitchen-sink/source/twig/theme/components/section-intro.twig
@@ -41,8 +41,8 @@
 
   <div class="umd-lock">
     <div class="content-heading type-hr">
-      <span class="type">Section Intro</span>
-      <span class="type-detail">Grouping Call to Action (5)</span>
+      <span>Section Intro</span>
+      <span>Grouping Call to Action (5)</span>
     </div>
   </div>
 
@@ -85,8 +85,8 @@
 
   <div class="umd-lock">
     <div class="content-heading type-hr">
-      <span class="type">Section Intro</span>
-      <span class="type-detail">Wide</span>
+      <span>Section Intro</span>
+      <span>Wide</span>
     </div>
   </div>
 

--- a/packages/kitchen-sink/source/twig/theme/components/sticky.twig
+++ b/packages/kitchen-sink/source/twig/theme/components/sticky.twig
@@ -4,8 +4,8 @@
   <section>
     <div class="umd-lock" style="padding-bottom: 50px">
       <div class="content-heading type-hr">
-        <span class="type">Listing Group (Events)</span>
-        <span class="type-detail">Featured Event</span>
+        <span>Listing Group (Events)</span>
+        <span>Featured Event</span>
       </div>
     </div>
 
@@ -571,8 +571,8 @@
   <section class="pb-2xl">
     <div class="umd-lock">
       <div class="content-heading">
-        <span class="type">Listing Group</span>
-        <span class="type-detail">People without images</span>
+        <span>Listing Group</span>
+        <span>People without images</span>
       </div>
 
       <div class="umd-sticky-listing" style="padding-top: 55px">
@@ -683,8 +683,8 @@
   <section style="padding-bottom: 30px">
     <div class="umd-lock">
       <div class="content-heading">
-        <span class="type">Listing Group</span>
-        <span class="type-detail">Provost Example with Feature card</span>
+        <span>Listing Group</span>
+        <span>Provost Example with Feature card</span>
       </div>
       <div class="umd-sticky-listing" style="padding-top: 55px">
         <div class="umd-sticky-featured">

--- a/packages/kitchen-sink/source/twig/theme/styles/listing.twig
+++ b/packages/kitchen-sink/source/twig/theme/styles/listing.twig
@@ -4,8 +4,8 @@
   <section>
     <div class="umd-lock" style="padding-bottom: 50px">
       <div class="content-heading type-hr">
-        <span class="type">Listing Group</span>
-        <span class="type-detail">Events</span>
+        <span>Listing Group</span>
+        <span>Events</span>
       </div>
     </div>
     <div class="umd-lock-smallest">
@@ -181,8 +181,8 @@
   <section class="pb-2xl" style="background-color: black">
     <div class="umd-lock" style="padding-bottom: 30px">
       <div class="content-heading type-hr">
-        <span class="type" style="color: white">Listing Group (People)</span>
-        <span class="type-detail">Dark Theme</span>
+        <span style="color: white">Listing Group (People)</span>
+        <span>Dark Theme</span>
       </div>
     </div>
     <div class="umd-lock-smallest">
@@ -277,8 +277,8 @@
   <section class="pb-2xl">
     <div class="umd-lock" style="padding-bottom: 50px">
       <div class="content-heading type-hr">
-        <span class="type">Listing Group (People)</span>
-        <span class="type-detail">Light Theme</span>
+        <span>Listing Group (People)</span>
+        <span>Light Theme</span>
       </div>
     </div>
     <div class="umd-lock-smallest">
@@ -372,8 +372,8 @@
   <section class="pb-2xl">
     <div class="umd-lock">
       <div class="content-heading type-hr">
-        <span class="type">Listing Group (People)</span>
-        <span class="type-detail">Without images</span>
+        <span>Listing Group (People)</span>
+        <span>Without images</span>
       </div>
 
       <div class="umd-lock-smallest">
@@ -452,8 +452,8 @@
   <section style="padding-bottom: 30px">
     <div class="umd-lock">
       <div class="content-heading type-hr" style="padding-bottom: 30px">
-        <span class="type">Listing Group</span>
-        <span class="type-detail">Eyebrow, Title, Date</span>
+        <span>Listing Group</span>
+        <span>Eyebrow, Title, Date</span>
       </div>
 
       <div class="umd-lock-smallest">
@@ -571,9 +571,9 @@
   </section>
   <section>
     <div class="umd-lock" style="padding-bottom: 50px">
-      <div class="content-heading">
-        <span class="type">Listing Group</span>
-        <span class="type-detail">Title, Rich Text, Image, Call to Action</span>
+      <div class="content-heading type-hr">
+        <span>Listing Group</span>
+        <span>Title, Rich Text, Image, Call to Action</span>
       </div>
     </div>
     <div class="umd-lock-smallest" style="padding-bottom: 50px">
@@ -688,9 +688,9 @@
   </section>
   <section>
     <div class="umd-lock" style="padding-bottom: 50px">
-      <div class="content-heading">
-        <span class="type">Listing Group</span>
-        <span class="type-detail">Title, Rich Text, Call to Action</span>
+      <div class="content-heading type-hr">
+        <span>Listing Group</span>
+        <span>Title, Rich Text, Call to Action</span>
       </div>
     </div>
     <div class="umd-lock-smallest" style="padding-bottom: 50px">

--- a/packages/kitchen-sink/source/twig/theme/styles/watermark.twig
+++ b/packages/kitchen-sink/source/twig/theme/styles/watermark.twig
@@ -4,8 +4,8 @@
   <section class="pb-2xl" style="padding: 80px 0">
     <div class="umd-lock">
       <div class="umd-sans-large type-hr">
-        <span class="type">Watermark</span>
-        <span class="type-detail">Font Size 5xl (Maximum 240px)</span>
+        <span>Watermark</span>
+        <span>Font Size 5xl (Maximum 240px)</span>
       </div>
     </div>
     <div class="umd-watermark-container">


### PR DESCRIPTION
Updating headline styles to remove classes and style by `span` for [DSYS-795](https://linear.app/umd-web-services/issue/DSYS-795/headline-styles)

[Updated staging](https://kitchen-sink-dev.umd-staging.com/components/pathway) (Pathway headings as example, but all headings are updated)